### PR TITLE
apparmor: Add network capability

### DIFF
--- a/gpsd2mqtt/apparmor.txt
+++ b/gpsd2mqtt/apparmor.txt
@@ -6,6 +6,7 @@ profile gpsd2mqtt flags=(attach_disconnected,mediate_deleted) {
   # Capabilities
   file,
   signal (send) set=(kill,term,int,hup,cont),
+  network,
 
   # S6-Overlay
   /init ix,


### PR DESCRIPTION
The addon doesn't appear to work on recent Debian without this; connection to the supervisor port from the container is blocked.

This fixes it on my installation.