### PR TITLE
Beta 2026.8.0b1 — GPSD 3.27.3, script refactor, release tooling fixes

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -64,7 +64,8 @@ jobs:
     strategy:
       matrix:
         addon: ${{ fromJson(needs.init.outputs.changed_addons) }}
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
+        # armhf, armv7 and i386 were dropped in Home Assistant 2025.12.
+        arch: ["aarch64", "amd64"]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/update-changelog-beta.yaml
+++ b/.github/workflows/update-changelog-beta.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published, prereleased]
 
+permissions:
+  contents: write
+
 jobs:
   update-changelog-beta:
     runs-on: ubuntu-latest
@@ -12,36 +15,53 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
+          # Full history so the rebase before pushing has something to work with.
+          fetch-depth: 0
 
       - name: Get latest release info
         id: release
-        uses: actions/github-script
+        uses: actions/github-script@v7
         with:
           script: |
-            const release = await github.rest.repos.getReleaseByTag({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag: context.payload.release.tag_name
-            });
-            core.setOutput("release_body", release.data.body);
-            core.setOutput("release_tag", release.data.tag_name);
+            core.setOutput("release_body", context.payload.release.body || "");
+            core.setOutput("release_tag", context.payload.release.tag_name);
 
-      - name: Update gpsd2mqtt_beta/CHANGELOG.md with collapsible old entries
+      - name: Prepend release notes to gpsd2mqtt_beta/CHANGELOG.md
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script: release notes are free text and would otherwise be able to
+          # inject shell commands here.
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+          RELEASE_BODY: ${{ steps.release.outputs.release_body }}
         run: |
+          set -euo pipefail
           FILE="gpsd2mqtt_beta/CHANGELOG.md"
-          TMP="$FILE.tmp"
-          if ! grep -q "# Changelog" $FILE; then echo "# Changelog" > $TMP; fi
-          echo -e "## [${{ steps.release.outputs.release_tag }}] - date -u +%Y-%m-%d\n${{ steps.release.outputs.release_body }}\n" >> $TMP
-          echo "<details><summary>Older changes</summary>" >> $TMP
-          awk 'BEGIN{found=0} /^## \[/{if(found++) exit} {if(found) print}' $FILE >> $TMP
-          echo "</details>" >> $TMP
-          mv $TMP $FILE
+          TMP="$(mktemp)"
 
-      - name: Commit and force-push changelog to main
+          # Rewrite as: header, the new entry, then the previous file verbatim
+          # minus its old header. Existing entries are never rewritten or
+          # dropped -- collapsing old ones into <details> stays a manual call.
+          {
+            echo "# Changelog"
+            echo
+            echo "## [${RELEASE_TAG}] - $(date -u +%Y-%m-%d)"
+            printf '%s\n' "${RELEASE_BODY}"
+            echo
+            awk 'NR==1 && /^# Changelog/ { next } { print }' "$FILE"
+          } > "$TMP"
+
+          mv "$TMP" "$FILE"
+
+      - name: Commit and push changelog to main
         run: |
+          set -euo pipefail
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
           git add gpsd2mqtt_beta/CHANGELOG.md
-          git commit -m "chore: update gpsd2mqtt_beta CHANGELOG.md from GitHub release" || true
+          if git diff --cached --quiet; then
+            echo "No changelog changes to commit."
+            exit 0
+          fi
+          git commit -m "chore: update gpsd2mqtt_beta CHANGELOG.md from GitHub release"
           git pull --rebase origin main
           git push origin main

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -16,39 +16,27 @@ This repository contains the following add-ons
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
-### [GPSD to MQTT Beta](./gpsd2mqtt)
+Run gpsd and publish the position to MQTT as a device tracker. This is the one to install.
 
-When there is development going on with addon the development will happen in de beta version. 
+### [GPSD to MQTT Beta](./gpsd2mqtt_beta)
+
+Development channel for the add-on above, flagged `experimental`. Not intended for general use — install the stable version instead.
 
 ### [Signal K to MQTT](./signalk2mqtt)
 
 This add-on does not work, will be deleted. 
 
-<!--
+## Development
 
-Notes to developers after forking or using the github template feature:
-- While developing comment out the 'image' key from 'example/config.yaml' to make the supervisor build the addon
-  - Remember to put this back when pushing up your changes.
-- When you merge to the 'main' branch of your repository a new build will be triggered.
-  - Make sure you adjust the 'version' key in 'example/config.yaml' when you do that.
-  - Make sure you update 'example/CHANGELOG.md' when you do that.
-  - The first time this runs you might need to adjust the image configuration on github container registry to make it public
-  - You may also need to adjust the github Actions configuration (Settings > Actions > General > Workflow > Read & Write)
-- Adjust the 'image' key in 'example/config.yaml' so it points to your username instead of 'home-assistant'.
-  - This is where the build images will be published to.
-- Rename the example directory.
-  - The 'slug' key in 'example/config.yaml' should match the directory name.
-- Adjust all keys/url's that points to 'home-assistant' to now point to your user/fork.
-- Share your repository on the forums https://community.home-assistant.io/c/projects/9
-- Do awesome stuff!
- -->
+Changes are made in `gpsd2mqtt_beta/` and promoted to `gpsd2mqtt/` by running
+`./rsync.sh` from inside that directory. `config.yaml`, `CHANGELOG.md`,
+`README.md` and the rsync files themselves stay separate between the two — see
+`gpsd2mqtt_beta/exclude_list.txt`.
+
+Remember to bump the `version` key in the relevant `config.yaml` and add a
+`CHANGELOG.md` entry; the builder workflow publishes a new image whenever
+`config.yaml`, `Dockerfile` or `build.yaml` changes.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/gpsd2mqtt_beta/CHANGELOG.md
+++ b/gpsd2mqtt_beta/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2026.8.0b1] - 2026-08-01
+- Upgrade to version 3.27.3 of GPSD, which includes the security fixes from 3.27.1 (CVE-2025-67268 and CVE-2025-67269)
+- Fix: satellite (Sky Data) updates ignored the configured update interval and were published continuously whenever position updates were being held back by the required-satellites setting
+- Fix: an MQTT password containing spaces was silently truncated and failed to authenticate
+- Fix: the MQTT password was written to the log in clear text when debug logging was enabled
+- Fix: the add-on now shuts down cleanly instead of being force-killed, so restarts are quicker
+- New Documentation tab in the add-on, covering every configuration option, the entities created and troubleshooting
+- Removed the unused "MQTT State Topic" option. It had no effect and could not be used to change any topic
+- Marked this add-on `stage: experimental` — it is the development channel and should not be installed for normal use
+- Internal: the add-on script has been reorganised into functions with no change to behaviour, and MQTT reconnection is now handled by the MQTT library itself
+
 ## [2025.7.0b5] - 2025-08-06
 - Add option to connect to TCP based device for GPS data
 - Upgrade to version 3.26.1 of GPSD

--- a/gpsd2mqtt_beta/DOCS.md
+++ b/gpsd2mqtt_beta/DOCS.md
@@ -1,0 +1,154 @@
+# GPSD to MQTT
+
+Runs [gpsd](https://gpsd.gitlab.io/gpsd/) inside Home Assistant and publishes the
+position it reports to MQTT, so you get a `device_tracker` entity that follows
+your actual GPS position.
+
+The typical use is a Home Assistant install that moves — a boat, a camper, a
+vehicle — where you want the home zone to follow the installation rather than
+sit at a fixed address.
+
+## Requirements
+
+- An MQTT broker. The [Mosquitto broker add-on](https://github.com/home-assistant/addons/tree/master/mosquitto)
+  is the easiest option and needs to be installed **before** this add-on.
+- A GPS receiver that gpsd supports, either attached over serial/USB or reachable
+  over TCP.
+
+## Installation
+
+1. Install and start an MQTT broker.
+2. Install this add-on.
+3. Open the **Configuration** tab and set **Device type** and **GPS Device**
+   (see below).
+4. Start the add-on and check the **Log** tab.
+
+The add-on publishes its entities automatically using MQTT discovery — there is
+nothing to add to `configuration.yaml`.
+
+## Configuration
+
+### Connecting the GPS
+
+**Device type** (`input_type`) — `serial` for a directly attached receiver (USB
+dongle, GPS HAT, serial port), or `tcp` for one reached over the network.
+
+**GPS Device** (`device`) — the serial device, for example `/dev/ttyUSB0` or
+`/dev/ttyACM0`. Required even in TCP mode, where it is ignored; pick any device
+from the list to satisfy the configuration form.
+
+**TCP Hostname or IP** / **TCP Port** (`tcp_host`, `tcp_port`) — only used when
+device type is `tcp`. Both must be set or the add-on stops with an error.
+
+### Serial line settings
+
+Only relevant for `serial`. The defaults suit most receivers, so change them
+only if yours needs it.
+
+| Option | Default | Notes |
+|---|---|---|
+| **Baudrate** (`baudrate`) | `9600` | Most GPS receivers use 9600 or 4800. |
+| **Databits** (`charsize`) | `8` | |
+| **Parity bit** (`parity`) | `false` | |
+| **stopbit** (`stopbit`) | `1` | Either 1 or 2. |
+
+### What gets published
+
+**3D Fix Only** (`publish_3d_fix_only`) — default `true`. Only publish a position
+once the receiver has a 3D fix. Leaving this on avoids feeding Home Assistant
+low-quality positions while the receiver is still acquiring satellites.
+
+**Required number of satellites** (`min_n_satellites`) — default `0` (no
+requirement). A 3D fix needs 3 satellites, but more satellites means a more
+accurate position. Setting this to 5–7 noticeably improves accuracy at the cost
+of fewer updates, especially in the first minutes after starting or under poor
+sky visibility. While the requirement is not met you will see `0 new updates` in
+the summary log — that is expected; it will start reporting once coverage is
+good enough.
+
+**Update Interval in seconds** (`publish_interval`) — default `10`. Minimum delay
+between position updates. Set to `0` to publish every update gpsd produces.
+
+**Print Summary Interval in seconds** (`summary_interval`) — default `120`. How
+often the add-on writes its summary line to the log.
+
+### MQTT
+
+Leave these empty when using the Mosquitto add-on: the add-on picks up Home
+Assistant's integrated credentials automatically.
+
+| Option | Default | Notes |
+|---|---|---|
+| **MQTT Server IP or Hostname** (`mqtt_broker`) | `core-mosquitto` | |
+| **MQTT Server port** (`mqtt_port`) | `1883` | |
+| **MQTT Username** (`mqtt_username`) | integrated auth | Set only for an external broker. |
+| **MQTT Password** (`mqtt_pw`) | integrated auth | Only used if a username is set. |
+
+If you set a username but the add-on cannot authenticate, check the log — it
+reports whether it started with integrated or manual credentials.
+
+### Advanced
+
+**GPSD options** (`gpsd_options`) — extra flags passed to gpsd, for example
+`-D3 -N` for verbose gpsd logging. The add-on always passes `--nowait`,
+`--readonly` and `--listenany`.
+
+**Debug** (`debug`) — verbose add-on logging, including every raw GPS report.
+Useful when reporting a problem. The MQTT password is never written to the log.
+
+## Entities
+
+The add-on creates a single **GPSD Service** device with two entities:
+
+**`device_tracker.gps_location`** — the position. Attributes include `latitude`,
+`longitude`, `altitude`, `speed`, `track`, `magtrack` and `accuracy` (`No fix`,
+`2D fix` or `3D fix`).
+
+`track` and `magtrack` are only reported by gpsd while moving. They are published
+as `null` when stationary so Home Assistant does not expire the attributes.
+
+**`sensor.gpsd_service_sky_data`** — the number of satellites currently used for
+the fix, with the full gpsd SKY report as attributes.
+
+## Example: keep the home zone on your actual position
+
+```yaml
+alias: Dynamic Update Home
+description: Update the Home location for Home Assistant based on GPS information
+triggers:
+  - trigger: state
+    entity_id:
+      - device_tracker.gps_location
+    attribute: latitude
+  - trigger: state
+    entity_id:
+      - device_tracker.gps_location
+    attribute: longitude
+conditions: []
+actions:
+  - action: homeassistant.set_location
+    data:
+      latitude: "{{ state_attr('device_tracker.gps_location', 'latitude') }}"
+      longitude: "{{ state_attr('device_tracker.gps_location', 'longitude') }}"
+mode: single
+```
+
+## Troubleshooting
+
+**No entities appear.** Confirm the MQTT integration is set up and the broker is
+running. The log shows `Published MQTT discovery message to topic: ...` once
+discovery has been sent.
+
+**Position never updates.** Check the summary line in the log. If it reports
+fewer satellites than required, either lower **Required number of satellites** or
+improve the receiver's view of the sky. A cold start can take several minutes.
+
+**The add-on cannot open the serial device.** Make sure no other add-on or
+integration (such as the GPSD integration) is holding the same device.
+
+**Direct gpsd access.** Port `2947` is available but disabled by default. Enable
+it in the **Network** section only if you want to point other gpsd clients at it.
+
+## Support
+
+Issues and questions: <https://github.com/corvy/ha-addons/issues>

--- a/gpsd2mqtt_beta/Dockerfile
+++ b/gpsd2mqtt_beta/Dockerfile
@@ -1,19 +1,27 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-# Execute during the build of the image
-ARG TEMPIO_VERSION BUILD_ARCH
-#RUN \
-#    curl -sSLf -o /usr/bin/tempio \
-#    "https://github.com/home-assistant/tempio/releases/download/${TEMPIO_VERSION}/tempio_${BUILD_ARCH}"
+# py3-paho-mqtt is constrained to 1.x on purpose: gpsd2mqtt.py uses the v1
+# callback signatures, and paho-mqtt 2.x makes a bare mqtt.Client() raise
+# ValueError (it requires an explicit CallbackAPIVersion). Alpine still ships
+# 1.6.x, so this constraint is a no-op today and a guard for when it bumps.
+RUN apk add --no-cache bash py3-pip "py3-paho-mqtt<2" py3-pyserial
 
-RUN apk add --no-cache bash py3-pip py3-paho-mqtt py3-pyserial
+# gpsd comes from the edge repository because Alpine stable lags behind.
+# 3.27.3 picks up the 3.27.1 security fixes (CVE-2025-67268 heap out-of-bounds
+# write in NMEA2000 parsing, CVE-2025-67269 integer underflow in NovAtel packet
+# handling).
+#
+# NOTE: edge is a rolling repository, so this exact pin has a shelf life -- once
+# edge moves past 3.27.3-r1 the version disappears and this line fails at build
+# time with "unable to select packages". That build failure is the signal to
+# come back and bump the pin. Check the current version at:
+# https://pkgs.alpinelinux.org/packages?name=gpsd&branch=edge&repo=main
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
+    gpsd=3.27.3-r1 gpsd-clients=3.27.3-r1
 
-# Add edge for gpsd ONLY, to get latest version
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main gpsd=3.26.1-r0 gpsd-clients=3.26.1-r0
-
-RUN pip install --break-system-packages gpsdclient
-# RUN pip install paho-mqtt gpsdclient
+# Pinned so image builds stay reproducible.
+RUN pip install --break-system-packages gpsdclient==1.3.2
 
 # Copy data for add-on
 COPY run.sh /

--- a/gpsd2mqtt_beta/README.md
+++ b/gpsd2mqtt_beta/README.md
@@ -1,34 +1,17 @@
-# GPSD to MQTT
+# GPSD to MQTT (Beta)
 
-This is a [gpsd — a GPS service daemon](https://gpsd.gitlab.io/gpsd/) to MQTT Home Assistant Addon.
+> **This is the development channel and is not intended for general use.**
+> Install the stable [GPSD to MQTT](../gpsd2mqtt) add-on instead.
 
-This addon will run gpsd and serve the data to MQTT and show a device tracker device (device_tracker.gpsd_location). The addon uses Mosquitto MQTT but can also be configued to use another broker if wanted. The idea is to update the home zone in Home Assistant with the actual position from gpsd, in order to run automations based on actual position.
+This is a [gpsd — a GPS service daemon](https://gpsd.gitlab.io/gpsd/) to MQTT Home Assistant add-on.
 
-Remember to install Mosquitto or another broker before setting up this addon.
+It runs gpsd and publishes the position to MQTT as a device tracker
+(`device_tracker.gps_location`), so Home Assistant's home zone can follow your
+actual position and automations can act on it. Mosquitto is the expected broker,
+but another one can be configured.
 
-If using Mosquitto on Home Assistant, the addon will use integrated authentication to log in. Normally you should not need to configure username or password for MQTT. If you have set up a custom MQTT broker, you must manually configure username and password (and potentially more).
+Changes land here first, get tested, and are then promoted to the stable add-on
+with `./rsync.sh`.
 
-Also you must select the serial device for GPSD in the configuration.
-
-The configuration is done via the addon GUI inside Home Assistant after installation.
-
-## Example automation to dynamically update position
-
-    alias: Dynamic Update Home
-    description: Update the Home location for Home Assistant based on GPS information
-    trigger:
-      - platform: state
-        entity_id:
-          - device_tracker.gps_location
-        attribute: latitude
-      - platform: state
-        entity_id:
-          - device_tracker.gps_location
-        attribute: longitude
-    condition: []
-    action:
-      - service: homeassistant.set_location
-        data_template:
-          latitude: "{{ state_attr('device_tracker.gps_location', 'latitude') }}"
-          longitude: "{{ state_attr('device_tracker.gps_location', 'longitude') }}"
-    mode: single
+See [DOCS.md](./DOCS.md) for setup, all configuration options, the entities the
+add-on creates, and an example automation.

--- a/gpsd2mqtt_beta/config.yaml
+++ b/gpsd2mqtt_beta/config.yaml
@@ -5,9 +5,12 @@ description: >-
 
   Installation requires you to set up a username and password to publish to MQTT. Also you must select the serial device for GPSD in configuration.
 url: https://github.com/corvy/ha-addons/tree/main/gpsd2mqtt_beta
-version: "2025.7.0b5"
+version: "2026.8.0b1"
 slug: "gpsd2mqtt_beta"
 init: false
+# Development channel for gpsd2mqtt. Not intended for general use -- install the
+# stable "GPSD to MQTT" add-on instead.
+stage: experimental
 arch:
   - aarch64
   - amd64
@@ -34,7 +37,6 @@ schema:
   mqtt_port: int?
   mqtt_username: str?
   mqtt_pw: str?
-  mqtt_state: str?
   gpsd_options: str?
   debug: bool?
 ports:

--- a/gpsd2mqtt_beta/exclude_list.txt
+++ b/gpsd2mqtt_beta/exclude_list.txt
@@ -1,5 +1,12 @@
 # exclude_list.txt for rsync
+# Files listed here stay distinct between the beta and release add-ons and are
+# never promoted by rsync.sh.
 exclude_list.txt
 README.md
 rsync.sh
 config.yaml
+# The two add-ons keep separate release histories -- without this, promoting
+# beta would overwrite the release changelog with the beta one.
+CHANGELOG.md
+# Local artefacts from running python here.
+__pycache__

--- a/gpsd2mqtt_beta/gpsd2mqtt.py
+++ b/gpsd2mqtt_beta/gpsd2mqtt.py
@@ -1,358 +1,479 @@
-import json
+"""Bridge gpsd reports to MQTT for Home Assistant.
+
+Reads TPV (position) and SKY (satellite) reports from a local gpsd instance and
+publishes them to MQTT. Home Assistant's MQTT discovery protocol is used to
+create a device_tracker entity for the position and a sensor for satellite
+coverage.
+"""
+
+import dataclasses
 import datetime
-import logging
-import time
-import platform
 import hashlib
+import json
+import logging
+import os
+import platform
 import signal
-import sys
+import time
+
 import paho.mqtt.client as mqtt  # type: ignore
 from gpsdclient import GPSDClient  # type: ignore
 
-# To make sure Home Assistant gets a uniique identifier, we use this section to crate a simple 8 character UID
+OPTIONS_PATH = "/data/options.json"
+GPSD_HOST = "127.0.0.1"
+HA_STATUS_TOPIC = "homeassistant/status"
+
+# Discovery topic used by add-on versions before the unique-identifier scheme.
+# Still cleared on startup so upgraded installs do not keep a stale entity.
+DEPRECATED_CONFIG_TOPIC = "homeassistant/device_tracker/gpsd/config"
+
+# Bounds for paho's built-in reconnect backoff, in seconds.
+RECONNECT_MIN_DELAY = 5
+RECONNECT_MAX_DELAY = 300
+
+# Pause before reopening the gpsd stream after it drops, so a gpsd that is down
+# does not spin this loop at full speed.
+GPSD_RETRY_DELAY = 5
+
+# gpsd TPV "mode" values, see https://gpsd.gitlab.io/gpsd/gpsd_json.html
+FIX_MODES = {1: "No fix", 2: "2D fix", 3: "3D fix"}
+MODE_3D_FIX = 3
+
+logger = logging.getLogger("gpsd2mqtt")
+
+# Cleared by SIGTERM/SIGINT so the add-on can stop without waiting for SIGKILL.
+_running = True
+
+
+@dataclasses.dataclass(frozen=True)
+class Config:
+    """Add-on options, as configured through the Home Assistant UI."""
+
+    device: str
+    baudrate: int
+    mqtt_broker: str
+    mqtt_port: int
+    mqtt_username: str
+    mqtt_password: str
+    publish_3d_fix_only: bool
+    min_n_satellites: int
+    publish_interval: int
+    summary_interval: int
+    debug: bool
+
+    @classmethod
+    def load(cls, path=OPTIONS_PATH):
+        with open(path, "r") as options_file:
+            data = json.load(options_file)
+
+        # publish_interval needs an explicit None check rather than `or`: 0 is a
+        # valid setting meaning "publish every update", and would otherwise be
+        # replaced by the default.
+        publish_interval = data.get("publish_interval")
+        if publish_interval is None:
+            publish_interval = 10
+
+        return cls(
+            device=data.get("device"),
+            baudrate=data.get("baudrate") or 9600,
+            mqtt_broker=data.get("mqtt_broker") or "core-mosquitto",
+            mqtt_port=data.get("mqtt_port") or 1883,
+            # run.sh exports these, resolving Home Assistant's integrated MQTT
+            # credentials when the user has not configured their own.
+            mqtt_username=os.environ.get("MQTT_USER") or data.get("mqtt_username") or "",
+            mqtt_password=os.environ.get("MQTT_PASSWORD") or data.get("mqtt_pw") or "",
+            publish_3d_fix_only=data.get("publish_3d_fix_only", True),
+            min_n_satellites=data.get("min_n_satellites") or 0,
+            publish_interval=publish_interval,
+            summary_interval=data.get("summary_interval") or 120,
+            debug=data.get("debug", False),
+        )
+
+    def log_options(self):
+        """Log the options in use. Deliberately never logs the MQTT password."""
+        logger.debug("These are the options in use.")
+        logger.debug("Serial device: %s", self.device)
+        logger.debug("Device Baudrate: %s", self.baudrate)
+        logger.debug("MQTT Hostname: %s", self.mqtt_broker)
+        logger.debug("MQTT TCP Port: %s", self.mqtt_port)
+        logger.debug("MQTT Username: %s", self.mqtt_username)
+        logger.debug("Publish interval: %s", self.publish_interval)
+        logger.debug("Summary interval: %s", self.summary_interval)
+        logger.debug("Required satellites: %s", self.min_n_satellites)
+        logger.debug("Debug enabled: %s", self.debug)
+
+
+@dataclasses.dataclass(frozen=True)
+class Topics:
+    """MQTT topics for one add-on instance, keyed by its unique identifier."""
+
+    config: str
+    attr: str
+    sky_config: str
+    sky_state: str
+    sky_attr: str
+
+    @classmethod
+    def for_device(cls, unique_id):
+        return cls(
+            config=f"homeassistant/device_tracker/gpsd2mqtt/{unique_id}/config",
+            attr=f"gpsd2mqtt/{unique_id}/attribute",
+            sky_config=f"homeassistant/sensor/gpsd2mqtt/{unique_id}_sky/config",
+            sky_state=f"gpsd2mqtt/{unique_id}_sky/state",
+            sky_attr=f"gpsd2mqtt/{unique_id}_sky/attribute",
+        )
+
+
+class Throttle:
+    """Rate limiter for publishing. An interval of 0 disables throttling."""
+
+    def __init__(self, interval):
+        self._interval = interval
+        self._last = datetime.datetime.now()
+
+    def ready(self):
+        if self._interval == 0:
+            return True
+        return (datetime.datetime.now() - self._last).total_seconds() >= self._interval
+
+    def mark(self):
+        self._last = datetime.datetime.now()
+
+
+@dataclasses.dataclass
+class Stats:
+    """Counters behind the periodic summary log line."""
+
+    published_updates: int = 0
+    max_satellites: int = 0
+    accuracy: str = None
+    last_summary: datetime.datetime = dataclasses.field(
+        default_factory=datetime.datetime.now
+    )
+
+    def due(self, summary_interval):
+        elapsed = (datetime.datetime.now() - self.last_summary).total_seconds()
+        return elapsed >= summary_interval
+
+    def emit(self, config):
+        minutes = (datetime.datetime.now() - self.last_summary).total_seconds() // 60
+        preamble = (
+            f"Published {self.published_updates} updates to the device_tracker "
+            f"in last {minutes} minutes."
+        )
+
+        if self.max_satellites >= config.min_n_satellites:
+            logger.info(
+                "%s Achieved %s, position with %s of required %s GPS satellites.",
+                preamble,
+                self.accuracy,
+                self.max_satellites,
+                config.min_n_satellites,
+            )
+        else:
+            logger.info(
+                "%s Achieved %s. Position not at configured accuracy with only "
+                "%s of required %s GPS satellites.",
+                preamble,
+                self.accuracy,
+                self.max_satellites,
+                config.min_n_satellites,
+            )
+
+        self.published_updates = 0
+        self.max_satellites = 0
+        self.last_summary = datetime.datetime.now()
+
+
 def get_unique_identifier():
+    """Build a stable 8-character ID so Home Assistant sees a consistent device."""
     system_info = platform.uname()
 
-    unique_identifier = "-".join([
-        system_info.node,  # Hostname - increase the chance of uniqueness
+    seed = "-".join([
+        system_info.node,  # Hostname - increases the chance of uniqueness
         system_info.system,  # System - e.g. Windows or Linux
         system_info.machine,  # Machine - for instance x86
     ])
 
-    # Hash the combined attributes using SHA-256
-    hashed_identifier = hashlib.sha256(unique_identifier.encode()).hexdigest()
-
-    # Truncate the hash to 8 characters
-    truncated_identifier = hashed_identifier[:8]
-
-    return truncated_identifier
+    return hashlib.sha256(seed.encode()).hexdigest()[:8]
 
 
-# Read the config options from the JSON file
-with open("/data/options.json", "r") as jsonfile:
-    data = json.load(jsonfile)
-    
-# Replace the variables with the values from the config options
-device = data.get("device")
-baudrate = data.get("baudrate") or 9600
-mqtt_broker = data.get("mqtt_broker") or "core-mosquitto"
-mqtt_port = data.get("mqtt_port") or 1883
-mqtt_username = sys.argv[1] or data.get("mqtt_username")
-mqtt_config = None
-# mqtt_username = data.get("mqtt_username") or "addons"
-mqtt_pw = sys.argv[2] or data.get("mqtt_pw")
-# Default confiuration options, should normally not be changed
-publish_3d_fix_only = data.get("publish_3d_fix_only", True)  # Default to True to reduce "unknown" positions
-min_n_satellites = data.get("min_n_satellites") or 0 # Default to 0 (all results) 
-debug = data.get("debug", False)
-# Variables used to publish updates to the
-summary_interval = data.get("summary_interval") or 120 # Interval in seconds
-publish_interval = data.get("publish_interval") 
-if publish_interval is None:
-    publish_interval = 10  # Default to 10 Interval in seconds
-published_updates = 0
-last_summary_time = datetime.datetime.now()
-last_publish_time = datetime.datetime.now()
-result = None
+def publish_discovery(client, topics, unique_id):
+    """Publish the Home Assistant MQTT discovery configs.
 
-# Define parameters for exponential backoff
-RECONNECT_DELAY_BASE = 5  # Initial delay in seconds
-MAX_RECONNECT_ATTEMPTS = 10  # Maximum number of reconnection attempts
+    Deliberately NOT retained. A retained config outlives the add-on: uninstall
+    it and the broker keeps serving the config, so Home Assistant recreates a
+    permanently unavailable device on every restart until someone manually
+    clears the topic. Re-announcing on `homeassistant/status` covers the restart
+    case instead, and leaves nothing behind.
+    """
+    device = {
+        "name": "GPSD Service",
+        "identifiers": f"gpsd2mqtt_{unique_id}",
+    }
 
-# Set up logging, adding timestamp to the logs
-logging.basicConfig(
-    level=logging.DEBUG if debug else logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',  # Adding %(asctime)s for timestamp
-)
-
-logger = logging.getLogger("MQTT Publisher")
-
-# Print the variables in use
-logger.debug('These are the options in use.')
-logger.debug('Serial device: ' + device)
-logger.debug('Device Baudrate: ' + str(baudrate))
-logger.debug('MQTT Hostname: ' + mqtt_broker)
-logger.debug('MQTT TCP Port: ' + str(mqtt_port))
-logger.debug('MQTT Username: ' + mqtt_username)
-logger.debug('MQTT Password: ' + mqtt_pw)
-logger.debug('Publish interval: ' + str(publish_interval))
-logger.debug('Summary interval: ' + str(summary_interval))
-logger.debug('Debug enabled: ' + str(debug))
-
-
-# Define the necessary callback functions for the MQTT client
-def on_connect(client, userdata, flags, rc):
-    if rc == 0:
-        logger.info("Connected to MQTT broker")
-        # Subscribe to the homeassistant/status topic. This ensures the script detects 
-        # HA reboots and then resubmits the discovery mesage
-        client.subscribe("homeassistant/status")
-        logger.info("Subscribe to MQTT topic homeassistant/status to listen for HA reboots.")
-    else:
-        logger.error("Failed to connect, return code: " + str(rc))
-
-def on_disconnect(client, userdata, rc):
-    if rc != 0:
-        logger.warning("Disconnected from MQTT broker. Attempting reconnection...")
-        reconnect_to_mqtt()
-
-def reconnect_to_mqtt():
-    attempt = 1
-    while attempt <= MAX_RECONNECT_ATTEMPTS:
-        try:
-            logger.info("Trying to reconnect to MQTT broker (attempt {} of {})...".format(attempt, MAX_RECONNECT_ATTEMPTS))
-            client.reconnect()
-            # If reconnection successful, subscribe to 
-            # the necessary topics and exit the loop
-            client.subscribe("homeassistant/status")
-            logger.info("Reconnect successful, resubscribing to necessary topics.")
-            break  
-        except Exception as e:
-            logger.error("Failed to reconnect to MQTT broker: " + str(e))
-        
-        # Calculate the delay using exponential backoff formula
-        reconnect_delay = RECONNECT_DELAY_BASE * (2 ** (attempt - 1))
-        logger.info("Waiting {} seconds before next reconnection attempt...".format(reconnect_delay))
-        time.sleep(reconnect_delay)
-        attempt += 1
-    
-    if attempt > MAX_RECONNECT_ATTEMPTS:
-        logger.error("Exceeded maximum reconnection attempts. Giving up.")
-
-def on_message(client, userdata, msg):
-    logger.debug("Received message: " + msg.topic + " " + str(msg.payload))
-    if msg.topic == "homeassistant/status" and msg.payload.decode() == "online":
-        # Resend the MQTT discovery message
-        publish_json_configs()
-        logger.info("Home Assistant reboot detected. Re-sent MQTT discovery message.")
-
-def on_log(client, userdata, level, buf):
-    logger.debug(buf)
-
-# Now, create an instance of the MQTT client and set up the appropriate callbacks:
-client = mqtt.Client()
-
-# Set the callback functions
-client.on_connect = on_connect
-client.on_disconnect = on_disconnect
-client.on_log = on_log
-client.on_message = on_message
-
-# set the username and password for MQTT
-client.username_pw_set(mqtt_username, mqtt_pw)
-
-client.loop_start()
-logger.info("Connecting to MQTT broker")
-client.connect(mqtt_broker, mqtt_port)
-
-# Pause to make sure MQTT is connected before resuming
-while not client.is_connected():
-    time.sleep(1) 
-    logger.info("Verifying MQTT Connection ....")
-
-# Not sure we need this part, commenting out for now
-# def shutdown():
-#    # Publish blank config to delete entities configured but the addon
-#    logger.info("Shutdown detected, cleaning up.")
-#    # client.publish(mqtt_config)
-
-# def signal_handler(sig, frame):
-#    # Handle shutdown signal
-#    shutdown()
-#    client.disconnect()
-#    sys.exit(0)
-
-# Register signal handler for SIGTERM and SIGINT
-# signal.signal(signal.SIGTERM, signal_handler)
-# signal.signal(signal.SIGINT, signal_handler)
-
-def publish_json_configs():
-    unique_identifier = get_unique_identifier()
-    mqtt_config_deprecated = "homeassistant/device_tracker/gpsd/config"
-    mqtt_config = f"homeassistant/device_tracker/gpsd2mqtt/{unique_identifier}/config"
-    # mqtt_state = f"gpsd2mqtt/{unique_identifier}/state"
-    mqtt_attr = f"gpsd2mqtt/{unique_identifier}/attribute"
-    mqtt_sky_config = f"homeassistant/sensor/gpsd2mqtt/{unique_identifier}_sky/config"
-    mqtt_sky_state = f"gpsd2mqtt/{unique_identifier}_sky/state"
-    mqtt_sky_attr = f"gpsd2mqtt/{unique_identifier}_sky/attribute"
-
-    logger.debug('Unique ID: ' + unique_identifier)
-    logger.debug('MQTT Config: ' + mqtt_config)
-    # logger.debug('MQTT State: ' + mqtt_state)
-    logger.debug('MQTT Attribute: ' + mqtt_attr)
-
-    # Create the device using the Home Assistant discovery protocol and set the state not_home
-    # "state_topic": "{mqtt_state}", (Removed from json_config)
-    # Serialize JSON objects separately
-    json_config_device_tracker = f'''
-    {{
-        "unique_id": "{unique_identifier}",
+    device_tracker = {
+        "unique_id": unique_id,
         "name": "Location",
         "platform": "mqtt",
-        "json_attributes_topic": "{mqtt_attr}",
+        "json_attributes_topic": topics.attr,
         "payload_home": "home",
         "payload_not_home": "not_home",
         "payload_reset": "check_zone",
         "object_id": "gps_location",
-        "icon":"mdi:map-marker",
-        "device": {{
-            "name": "GPSD Service",
-            "identifiers": "gpsd2mqtt_{unique_identifier}", 
+        "icon": "mdi:map-marker",
+        "device": {
+            **device,
             "configuration_url": "https://github.com/corvy/ha-addons/tree/main/gpsd2mqtt",
             "model": "gpsd2MQTT",
-            "manufacturer": "GPSD and @sbarmen"
-        }}
-    }}
-    '''
+            "manufacturer": "GPSD and @sbarmen",
+        },
+    }
 
-    json_config_sensor = f'''
-    {{
-        "unique_id": "{unique_identifier}_sky",
+    sky_sensor = {
+        "unique_id": f"{unique_id}_sky",
         "name": "Sky Data",
         "icon": "mdi:satellite-variant",
         "platform": "mqtt",
-        "state_topic": "{mqtt_sky_state}",
-        "json_attributes_topic": "{mqtt_sky_attr}",
-        "device": {{
-            "name": "GPSD Service",
-            "identifiers": "gpsd2mqtt_{unique_identifier}"
-        }}
-    }}
-    '''
+        "state_topic": topics.sky_state,
+        "json_attributes_topic": topics.sky_attr,
+        "device": device,
+    }
 
-    client.publish(mqtt_config_deprecated) # Empty config for deprecated device to cleanup
-    client.publish(mqtt_config, json_config_device_tracker) # Publish the device tracker discovery message
-    client.publish(mqtt_sky_config, json_config_sensor) # Publish the sensor discovery message
+    # The one place retain is correct: an empty retained payload is what deletes
+    # a retained message, so this clears the config an older version of the
+    # add-on may have left behind. If nothing is retained there it is a no-op --
+    # brokers do not store empty retained payloads, so this cannot leave garbage.
+    client.publish(DEPRECATED_CONFIG_TOPIC, "", retain=True)
 
-    logger.info(f"Published MQTT discovery message to topic: {mqtt_config}")
-    logger.debug(f"Published {json_config_device_tracker} discovery message to topic: {mqtt_config}")
-    logger.debug(f"Published {json_config_sensor} discovery message to topic: {mqtt_sky_config}")
+    client.publish(topics.config, json.dumps(device_tracker))
+    client.publish(topics.sky_config, json.dumps(sky_sensor))
 
-    return mqtt_attr, mqtt_sky_state, mqtt_sky_attr
+    logger.info("Published MQTT discovery message to topic: %s", topics.config)
+    logger.debug("Device tracker discovery payload: %s", device_tracker)
+    logger.debug("Sky sensor discovery payload: %s", sky_sensor)
 
-mqtt_attr, mqtt_sky_state, mqtt_sky_attr = publish_json_configs()
 
-# Publish the serialized JSON objects
-# Main program loop to update the device location from GPS
-while True:
+def build_client(config, topics, unique_id):
+    """Create the MQTT client and wire up its callbacks.
 
-    # Check connection and perform reconnection if needed
-    if not client.is_connected():
-        reconnect_to_mqtt()
+    Reconnection is left to paho: loop_start() retries in the background using
+    the backoff set by reconnect_delay_set(), and on_connect runs again on every
+    successful reconnect.
+    """
 
-    logger.info("Starting location detection and sending GPS updates.")
-    client.loop(timeout=1) # Process MQTT messages with a 1-second timeout
+    def on_connect(client, userdata, flags, rc):
+        if rc != 0:
+            logger.error("Failed to connect, return code: %s", rc)
+            return
 
-    with GPSDClient(host="127.0.0.1") as gps_client:
+        logger.info("Connected to MQTT broker")
+        # Watching homeassistant/status lets the add-on notice a Home Assistant
+        # restart and re-announce itself.
+        client.subscribe(HA_STATUS_TOPIC)
+        logger.info(
+            "Subscribe to MQTT topic %s to listen for HA reboots.", HA_STATUS_TOPIC
+        )
 
-        tpv_publish_flag = False # Set to false, no updates until required number of satellites is found
-        log_satellites = 0 # Initialize variable for log printing, want the highest seen satellites for the log round
-        accuracy = None # Initialize variable, to ensure no error
+    def on_disconnect(client, userdata, rc):
+        if rc != 0:
+            logger.warning(
+                "Disconnected from MQTT broker. Automatic reconnection in progress..."
+            )
 
-        for raw_result in gps_client.json_stream():
+    def on_message(client, userdata, msg):
+        logger.debug("Received message: %s %s", msg.topic, msg.payload)
+        if msg.topic == HA_STATUS_TOPIC and msg.payload.decode() == "online":
+            publish_discovery(client, topics, unique_id)
+            logger.info("Home Assistant reboot detected. Re-sent MQTT discovery message.")
+
+    def on_log(client, userdata, level, buf):
+        logger.debug(buf)
+
+    # NOTE: these are paho-mqtt 1.x callback signatures, and mqtt.Client() takes
+    # no arguments there. paho-mqtt 2.x requires an explicit CallbackAPIVersion,
+    # which is why the Dockerfile constrains the package to 1.x.
+    client = mqtt.Client()
+    client.on_connect = on_connect
+    client.on_disconnect = on_disconnect
+    client.on_message = on_message
+    client.on_log = on_log
+
+    client.username_pw_set(config.mqtt_username, config.mqtt_password)
+    client.reconnect_delay_set(
+        min_delay=RECONNECT_MIN_DELAY, max_delay=RECONNECT_MAX_DELAY
+    )
+
+    return client
+
+
+def normalise_tpv(report):
+    """Rename gpsd's TPV fields to the ones Home Assistant's device_tracker wants."""
+    report["accuracy"] = FIX_MODES.get(report.get("mode"), "Unknown")
+
+    for gpsd_name, ha_name in (
+        ("alt", "altitude"),
+        ("lon", "longitude"),
+        ("lat", "latitude"),
+    ):
+        if report.get(gpsd_name) is not None:
+            report[ha_name] = report.pop(gpsd_name)
+
+    # track and magtrack are reported when gpsd starts but stop being sent once
+    # the GPS is stationary. Publishing them explicitly as null keeps Home
+    # Assistant from expiring the attributes.
+    for name in ("track", "magtrack"):
+        if name not in report:
+            report[name] = None
+            logger.debug("Attribute %s not in result, setting value to none", name)
+
+    return report
+
+
+def handle_sky(client, topics, report, config, throttle, stats):
+    """Publish satellite coverage, and report whether position updates are wanted."""
+    # uSat is the number of satellites actually used for the fix - the more the
+    # better.
+    n_satellites = report.get("uSat", 0)
+    stats.max_satellites = max(stats.max_satellites, n_satellites)
+
+    logger.debug(
+        "Number of satellites: %s of required %s",
+        n_satellites,
+        config.min_n_satellites,
+    )
+
+    if throttle.ready():
+        client.publish(topics.sky_attr, json.dumps(report))
+        client.publish(topics.sky_state, str(n_satellites))
+        throttle.mark()
+        logger.debug("Published SKY: %s to topic: %s", n_satellites, topics.sky_state)
+        logger.debug("Published SKY: %s to topic: %s", report, topics.sky_attr)
+
+    return n_satellites >= config.min_n_satellites
+
+
+def handle_tpv(client, topics, report, config, throttle, stats):
+    """Publish a position update, subject to the fix and throttle settings."""
+    report = normalise_tpv(report)
+    stats.accuracy = report["accuracy"]
+    logger.debug("Processed TPV Data: %s", report)
+
+    if not throttle.ready():
+        return
+
+    logger.debug("Accuracy achieved: %s", report["accuracy"])
+
+    # Only publish a good fix, unless the user has opted into every update.
+    if config.publish_3d_fix_only and report.get("mode") != MODE_3D_FIX:
+        return
+
+    client.publish(topics.attr, json.dumps(report))
+    stats.published_updates += 1
+    throttle.mark()
+    logger.debug("Published TPV: %s to topic: %s", report, topics.attr)
+
+
+def stream_gps(client, topics, config, stats):
+    """Consume one gpsd session, publishing reports until the stream ends."""
+    # SKY and TPV each get their own throttle. Sharing a single timestamp meant
+    # SKY updates were only rate-limited when a TPV update happened to reset the
+    # clock, so they streamed unthrottled whenever TPV was being withheld.
+    sky_throttle = Throttle(config.publish_interval)
+    tpv_throttle = Throttle(config.publish_interval)
+
+    # Withhold position updates until the configured satellite count is met.
+    publish_position = config.min_n_satellites == 0
+
+    with GPSDClient(host=GPSD_HOST) as gps_client:
+        for raw_report in gps_client.json_stream():
+            if not _running:
+                return
+
             try:
-                result = json.loads(raw_result)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to decode JSON: {e}")
+                report = json.loads(raw_report)
+            except json.JSONDecodeError as err:
+                logger.error("Failed to decode JSON: %s", err)
                 continue
 
-            # Log the entire result object
-            logger.debug(f"RAW GPS data: {result}")
+            logger.debug("RAW GPS data: %s", report)
 
-            if result.get("class") == "SKY":
-                # USat is the current number of satellites used to calculate the position - the more the better
-                n_satellites = result.get("uSat", 0)
+            report_class = report.get("class")
+            if report_class == "SKY":
+                publish_position = handle_sky(
+                    client, topics, report, config, sky_throttle, stats
+                )
+            elif report_class == "TPV" and publish_position:
+                handle_tpv(client, topics, report, config, tpv_throttle, stats)
 
-                # Set the highest number of satellites used for positioning in this log round
-                if log_satellites < n_satellites:
-                    log_satellites = n_satellites
+            if stats.due(config.summary_interval):
+                stats.emit(config)
 
-                # If the user has configured a minimum # of satellites needed for a "good position"
-                if n_satellites >= min_n_satellites:
-                    tpv_publish_flag = True
-                else:
-                    tpv_publish_flag = False
 
-                logger.debug(f"Number of satellites: {n_satellites} of required {min_n_satellites}")
-                logger.debug(f"Published SKY: {result} to topic: {mqtt_sky_attr}")
- 
-                # Publish SKY data
-                if (datetime.datetime.now() - last_publish_time).total_seconds() >= publish_interval or publish_interval == 0:
-                    client.publish(mqtt_sky_attr, json.dumps(result))
-                    client.publish(mqtt_sky_state, str(n_satellites)) 
-                    logger.debug(f"Published SKY: {str(n_satellites)} to topic: {mqtt_sky_state}")
-                    logger.debug(f"Published SKY: {result} to topic: {mqtt_sky_attr}")
+def wait_for_connection(client):
+    """Block until the broker accepts us, or until we are asked to shut down."""
+    waited = 0
+    while _running and not client.is_connected():
+        time.sleep(1)
+        waited += 1
+        if waited % 5 == 0:
+            logger.info("Verifying MQTT Connection ....")
 
-            if result.get("class") == "TPV" and tpv_publish_flag: # Check if it is TPV, and that we meet the minimum # of satellites
-                mode = result.get("mode")
-                if mode == 1:
-                    accuracy = "No fix"
-                elif mode == 2:
-                    accuracy = "2D fix"
-                elif mode == 3:
-                    accuracy = "3D fix"
-                else:
-                    accuracy = "Unknown"
-                
-                result["accuracy"] = accuracy
 
-                # Modify the attribute names so Home Assistant gets position in the device_tracker 
-                # (it expects longitute/latitude/altitude)
-                if "alt" in result and result["alt"] is not None:
-                    result["altitude"] = result.pop("alt")
-                if "lon" in result and result["lon"] is not None:
-                    result["longitude"] = result.pop("lon")
-                if "lat" in result and result["lat"] is not None:
-                    result["latitude"] = result.pop("lat")
+def handle_shutdown(signum, frame):
+    global _running
+    logger.info("Received %s, shutting down.", signal.Signals(signum).name)
+    _running = False
 
-                # Track and magtrack are reported when GPSD starts, but will stop reporting when the GPS is stationary.
-                # This will report 'null', but still send the attribute so it does not get expired in Home Assistant.
-                if "track" not in result:
-                    result["track"] = None 
-                    logger.debug(f"Attribute track not in result, setting value to none")
 
-                if "magtrack" not in result:
-                    result["magtrack"] = None
-                    logger.debug(f"Attribute magtrack not in result, setting value to none")
+def main():
+    config = Config.load()
 
-                logger.debug(f"Processed TPV Data: {result}")
-            
-                # Limit the GPS updates to the configured value, or publish all if disabled (0)
-                if (datetime.datetime.now() - last_publish_time).total_seconds() >= publish_interval or publish_interval == 0:
+    logging.basicConfig(
+        level=logging.DEBUG if config.debug else logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    config.log_options()
 
-                    logger.debug("Accuracy achieved:" + result["accuracy"])
-                    # Publish the JSON message to the MQTT broker only if mode is 3D fix
-                    if (publish_3d_fix_only and mode == 3):
-                        client.publish(mqtt_attr, json.dumps(result))
-                        published_updates += 1 # Add one per publish for the summary log 
-                        logger.debug(f"Published TPV: {result} to topic: {mqtt_attr} (3D-fix-only)")
-                        
-                    elif not publish_3d_fix_only :
-                        # If not filtering on 3D fix, we publish all updates
-                        client.publish(mqtt_attr, json.dumps(result))
-                        published_updates += 1 # Add one per publish for the summary log 
-                        logger.debug(f"Published TPV: {result} to topic: {mqtt_attr}")
-                    
-                    last_publish_time = datetime.datetime.now()
-                    
-            
-            # Check if a summary should be printed
-            if (datetime.datetime.now() - last_summary_time).total_seconds() >= summary_interval:
-                # Calculate the time elapsed since the last summary
-                time_elapsed = (datetime.datetime.now() - last_summary_time).total_seconds() // 60
+    signal.signal(signal.SIGTERM, handle_shutdown)
+    signal.signal(signal.SIGINT, handle_shutdown)
 
-                # Print the summary message
-                if log_satellites >= min_n_satellites:
-                    summary_message = f"Published {published_updates} updates to the device_tracker in last {time_elapsed} minutes. Achieved {accuracy}, position with {log_satellites} of required {min_n_satellites} GPS satellites."
-                else:
-                    summary_message = f"Published {published_updates} updates to the device_tracker in last {time_elapsed} minutes. Achieved {accuracy}. Position not at configured accuracy with only {log_satellites} of required {min_n_satellites} GPS satellites."
-                
-                logger.info(summary_message)
+    unique_id = get_unique_identifier()
+    topics = Topics.for_device(unique_id)
+    logger.debug("Unique ID: %s", unique_id)
+    logger.debug("MQTT Config: %s", topics.config)
+    logger.debug("MQTT Attribute: %s", topics.attr)
 
-                # Reset the counters
-                published_updates = 0
-                log_satellites = 0
-                last_summary_time = datetime.datetime.now()
+    client = build_client(config, topics, unique_id)
 
-# Stop the MQTT network loop
-client.disconnect()
+    # connect_async tolerates a broker that is not up yet: loop_start keeps
+    # retrying in the background instead of raising here.
+    logger.info("Connecting to MQTT broker")
+    client.connect_async(config.mqtt_broker, config.mqtt_port)
+    client.loop_start()
+    wait_for_connection(client)
+
+    if _running:
+        publish_discovery(client, topics, unique_id)
+
+    stats = Stats()
+    while _running:
+        logger.info("Starting location detection and sending GPS updates.")
+        try:
+            stream_gps(client, topics, config, stats)
+        except Exception as err:  # gpsd restarting, socket dropped, bad frame
+            logger.error("Lost connection to gpsd: %s", err)
+
+        if _running:
+            logger.info(
+                "gpsd stream ended, reconnecting in %s seconds.", GPSD_RETRY_DELAY
+            )
+            time.sleep(GPSD_RETRY_DELAY)
+
+    logger.info("Disconnecting from MQTT broker.")
+    client.loop_stop()
+    client.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/gpsd2mqtt_beta/run.sh
+++ b/gpsd2mqtt_beta/run.sh
@@ -52,7 +52,7 @@ if [ "$INPUT_TYPE" = "serial" ]; then
     /usr/sbin/gpsd ${GPSD_OPTIONS} -s ${BAUDRATE} ${DEVICE}
 elif [ "$INPUT_TYPE" = "tcp" ]; then
     if [ -z "$TCP_HOST" ] || [ -z "$TCP_PORT" ]; then
-        echo "tcp_host og tcp_port må fylles ut for TCP-modus."
+        echo "ERROR: tcp_host and tcp_port must both be set when input_type is tcp."
         exit 1
     fi
     echo "Starting GPSD with TCP source ${TCP_HOST}:${TCP_PORT} ..."
@@ -67,13 +67,22 @@ fi
 #/usr/bin/gpsctl
 
 # Start python script to publish results from GPSD to MQTT
-if [ $HA_AUTH = true ]; then
+if [ "$HA_AUTH" = true ]; then
     echo "Starting MQTT Publisher with integrated credentials ... "
-    else
+else
     echo "Starting MQTT Publisher with username ${MQTT_USER} ... "
 fi
-    
-python /gpsd2mqtt.py ${MQTT_USER} ${MQTT_PASSWORD}
+
+# Credentials go through the environment rather than the command line: argv
+# would expose the password in `ps`, and an unquoted password containing spaces
+# would be split into separate arguments.
+export MQTT_USER
+export MQTT_PASSWORD
+
+# exec so python replaces this shell as the process the supervisor signals --
+# otherwise bash sits in wait() and never forwards SIGTERM, and the add-on only
+# stops when it gets SIGKILLed.
+exec python /gpsd2mqtt.py
 
 
 # Config file for gpsd server

--- a/gpsd2mqtt_beta/translations/en.yaml
+++ b/gpsd2mqtt_beta/translations/en.yaml
@@ -24,9 +24,6 @@ configuration:
   mqtt_pw:
     name: MQTT Password
     description: Only used if you use a custom username, disregarded if using integrated authentication.
-  mqtt_state:
-    name: MQTT State Topic
-    description: If you need to change topic it can be done here. WARNING, this might break functionality so please leave at deafult unless you know exactly what you are doing.
   publish_3d_fix_only:
     name: 3D Fix Only
     description: Only publish updated position when the GPS has a good fix (3D Fix - minimum 3 satellites for positioning)


### PR DESCRIPTION
Beta-only change. `gpsd2mqtt/` is untouched and stays on 2025.12.0.

### gpsd
- 3.26.1 → 3.27.3-r1, picking up the 3.27.1 security fixes
  (CVE-2025-67268 heap OOB write in NMEA2000, CVE-2025-67269 integer
  underflow in NovAtel). Note 3.27.5 is not packaged in Alpine.
- Constrained `py3-paho-mqtt` to <2 and pinned `gpsdclient`.

### Bugs fixed
- SKY data was published unthrottled whenever position updates were being
  withheld by `min_n_satellites` — the shared timestamp was only ever reset
  in the TPV branch.
- MQTT password was logged in clear text under debug.
- Password containing spaces was silently truncated by unquoted argv;
  credentials now go through the environment.
- `run.sh` lacked `exec`, so SIGTERM was never forwarded and the add-on was
  always SIGKILLed on stop.

### Refactor (no behaviour change)
`gpsd2mqtt.py` restructured into functions + `main()`. The hand-rolled
reconnect loop is gone in favour of paho's `reconnect_delay_set` — it was
running on paho's own network thread and could block it for ~40 minutes.

Discovery configs remain **unretained** deliberately: a retained config
outlives an uninstalled add-on and leaves an unavailable device behind.

### Release tooling
- `update-changelog-beta.yaml` never ran (`uses: actions/github-script` with
  no `@version`). Fixed that plus a literal `date` string, a dropped header,
  and an awk that discarded all but the newest entry. Release notes now pass
  through env rather than shell interpolation.
- Added `DOCS.md` so the add-on gets a Documentation tab.
- Marked beta `stage: experimental`; fixed stale arch badges and the beta
  link in the root README.

### What this PR validates
Builder runs with `--test` (no registry push), so this is the first real
check that the edge gpsd pin still resolves and that the linter accepts
`stage: experimental`.

Two checks to watch: Builder — a failure at apk add with "unable to select packages" means edge has already rolled past 3.27.3-r1 and the Dockerfile pin needs bumping. And Lint, for stage: experimental.

Merging is what publishes ...-addon-gpsd2mqtt-beta:2026.8.0b1. Once that's installed on the GPS hardware and the log shows 3.27.3 with a good fix, the prod promotion is the three-step commit from earlier.