### PR TITLE
Add python tests and linting to CI, replace changed-files action

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -22,10 +22,40 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6
+        with:
+          # Full history so the diff below can reach the merge base.
+          fetch-depth: 0
 
       - name: Get changed files
         id: changed_files
-        uses: jitterbit/get-changed-files@v1
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            # Diff against the merge base, not the base tip. Comparing to the tip
+            # requires the PR head to be a strict descendant of base, which it is
+            # not after main receives a merge commit that dev never got -- that is
+            # what the previous action failed on.
+            base="$(git merge-base "${PR_BASE_SHA}" "${PR_HEAD_SHA}")"
+            head="${PR_HEAD_SHA}"
+          else
+            base="${PUSH_BEFORE}"
+            head="${PUSH_AFTER}"
+            # An all-zero "before" means a new branch or a force push, where there
+            # is no previous state to compare against.
+            if [[ -z "${base}" || "${base}" =~ ^0+$ ]] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
+              base="${head}^"
+            fi
+          fi
+
+          echo "Comparing ${base}...${head}"
+          git diff --name-only "${base}" "${head}" | tee /tmp/changed_files.txt
 
       - name: Find add-on directories
         id: addons
@@ -34,28 +64,31 @@ jobs:
       - name: Get changed add-ons
         id: changed_addons
         run: |
-          declare -a changed_addons
+          set -euo pipefail
+
+          declare -a changed_addons=()
           for addon in ${{ steps.addons.outputs.addons }}; do
-            if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon ]]; then
-              for file in ${{ env.MONITORED_FILES }}; do
-                  if [[ "${{ steps.changed_files.outputs.all }}" =~ $addon/$file ]]; then
-                    if [[ ! "${changed_addons[@]}" =~ $addon ]]; then
-                      changed_addons+=("\"${addon}\",");
-                    fi
-                  fi
-              done
-            fi
+            for file in ${{ env.MONITORED_FILES }}; do
+              # Exact path match. The previous compare was an unanchored regex and
+              # worked only by luck of the directory names. The second grep covers
+              # `rootfs`, which is a directory rather than a file.
+              if grep -qxF "${addon}/${file}" /tmp/changed_files.txt \
+                || grep -qF "${addon}/${file}/" /tmp/changed_files.txt; then
+                changed_addons+=("${addon}")
+                break
+              fi
+            done
           done
 
-          changed=$(echo ${changed_addons[@]} | rev | cut -c 2- | rev)
-
-          if [[ -n ${changed} ]]; then
-            echo "Changed add-ons: $changed";
-            echo "changed=true" >> $GITHUB_OUTPUT;
-            echo "addons=[$changed]" >> $GITHUB_OUTPUT;
-          else
+          if [[ ${#changed_addons[@]} -eq 0 ]]; then
             echo "No add-on had any monitored files changed (${{ env.MONITORED_FILES }})";
+            exit 0
           fi
+
+          echo "Changed add-ons: ${changed_addons[*]}";
+          printf -v json '"%s",' "${changed_addons[@]}"
+          echo "changed=true" >> $GITHUB_OUTPUT;
+          echo "addons=[${json%,}]" >> $GITHUB_OUTPUT;
   build:
     needs: init
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,10 +17,10 @@ jobs:
     outputs:
       addons: ${{ steps.addons.outputs.addons_list }}
     steps:
-      - name: ⤵️ Check out code from GitHub
+      - name: Check out code from GitHub
         uses: actions/checkout@v6
 
-      - name: 🔍 Find add-on directories
+      - name: Find add-on directories
         id: addons
         uses: home-assistant/actions/helpers/find-addons@master
 
@@ -32,10 +32,34 @@ jobs:
       matrix:
         path: ${{ fromJson(needs.find.outputs.addons) }}
     steps:
-      - name: ⤵️ Check out code from GitHub
+      - name: Check out code from GitHub
         uses: actions/checkout@v6
 
-      - name: 🚀 Run Home Assistant Add-on Lint
+      - name: Run Home Assistant Add-on Lint
         uses: frenck/action-addon-linter@v2.21
         with:
           path: "./${{ matrix.path }}"
+
+  python:
+    name: Lint and test the add-on script
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: pip install -r tests/requirements.txt
+
+      - name: Ruff
+        run: ruff check .
+
+      # Tests import the add-on module from gpsd2mqtt_beta/, which is the source of
+      # truth. gpsd2mqtt/ is a copy produced by rsync.sh and is deliberately not
+      # linted or tested separately.
+      - name: Pytest
+        run: pytest tests/ -v

--- a/gpsd2mqtt_beta/gpsd2mqtt.py
+++ b/gpsd2mqtt_beta/gpsd2mqtt.py
@@ -63,7 +63,7 @@ class Config:
 
     @classmethod
     def load(cls, path=OPTIONS_PATH):
-        with open(path, "r") as options_file:
+        with open(path) as options_file:
             data = json.load(options_file)
 
         # publish_interval needs an explicit None check rather than `or`: 0 is a

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,25 @@
+# Pinned explicitly so CI and a local run agree regardless of ruff's shifting
+# defaults or any user-level config.
+
+line-length = 100
+target-version = "py311"
+
+include = ["gpsd2mqtt_beta/*.py", "tests/*.py", "scripts/*.py"]
+
+# `gpsd2mqtt/` is a copy of `gpsd2mqtt_beta/` produced by rsync.sh. Linting it would
+# report every finding twice and invite fixing it in the wrong place.
+exclude = ["gpsd2mqtt"]
+
+[lint]
+select = [
+    "E",   # pycodestyle
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # import sorting
+    "B",   # bugbear
+    "UP",  # pyupgrade
+]
+
+[lint.per-file-ignores]
+# conftest.py has to extend sys.path before it can import the add-on module.
+"tests/conftest.py" = ["E402"]

--- a/scripts/check_addons.py
+++ b/scripts/check_addons.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Check invariants across the add-on config.yaml files.
+
+`config.yaml` is deliberately excluded from `gpsd2mqtt_beta/rsync.sh`, because the
+slug, name, version and image must differ between the two channels. The cost is
+that schema changes have to be mirrored by hand, and nothing used to notice when
+that was forgotten -- `mqtt_state` was removed from beta in 2026.8.0 and the prod
+changelog said so, but it sat in the prod schema for another release.
+
+Run from the repository root, or with the repository root as the only argument.
+"""
+
+import pathlib
+import re
+import sys
+
+import yaml
+
+# The two channels of the same add-on. Everything a user configures must be
+# identical between them; only packaging differs.
+MIRRORED_CHANNELS = ("gpsd2mqtt", "gpsd2mqtt_beta")
+
+# Keys that must match across the channels above.
+MIRRORED_KEYS = ("schema", "options")
+
+# The beta channel's version carries a bN suffix. Nothing else may.
+BETA_SUFFIX = re.compile(r"b\d*$")
+
+
+def load_addons(root):
+    """Return {slug: config} for every add-on directory under root."""
+    addons = {}
+    for config_path in sorted(root.glob("*/config.yaml")):
+        with open(config_path) as config_file:
+            addons[config_path.parent.name] = yaml.safe_load(config_file)
+    return addons
+
+
+def check_mirrored_keys(addons, errors):
+    """The user-facing configuration must be identical across both channels."""
+    present = [slug for slug in MIRRORED_CHANNELS if slug in addons]
+    if len(present) < 2:
+        return
+
+    first, second = present[0], present[1]
+    for key in MIRRORED_KEYS:
+        left = addons[first].get(key)
+        right = addons[second].get(key)
+        if left == right:
+            continue
+
+        left_keys = set(left or {})
+        right_keys = set(right or {})
+        for extra in sorted(left_keys - right_keys):
+            errors.append(f"{first}/config.yaml has `{key}.{extra}`, {second} does not")
+        for extra in sorted(right_keys - left_keys):
+            errors.append(f"{second}/config.yaml has `{key}.{extra}`, {first} does not")
+        for shared in sorted(left_keys & right_keys):
+            if (left or {})[shared] != (right or {})[shared]:
+                errors.append(
+                    f"`{key}.{shared}` differs: "
+                    f"{first}={(left or {})[shared]!r}, {second}={(right or {})[shared]!r}"
+                )
+
+
+def check_versions(addons, errors):
+    """Release tags come from `version:` and are repository-wide, so they must be unique."""
+    seen = {}
+    for slug, config in addons.items():
+        version = str(config.get("version", ""))
+        if not version:
+            errors.append(f"{slug}/config.yaml has no version")
+            continue
+
+        # Two add-ons at the same version would collide on the GitHub release tag
+        # created by .github/workflows/release.yaml, and the second would be
+        # silently skipped.
+        if version in seen:
+            errors.append(
+                f"{slug} and {seen[version]} both declare version {version}; "
+                "release tags are repository-wide and must be unique"
+            )
+        seen[version] = slug
+
+        # This is what keeps the uniqueness above true by construction rather
+        # than by luck: beta always carries the suffix, prod never does.
+        is_beta_channel = slug.endswith("_beta")
+        has_beta_suffix = bool(BETA_SUFFIX.search(version))
+        if is_beta_channel and not has_beta_suffix:
+            errors.append(f"{slug} version {version} must end in a bN suffix")
+        if not is_beta_channel and has_beta_suffix:
+            errors.append(f"{slug} version {version} must not end in a bN suffix")
+
+
+def check_images(addons, errors):
+    """Each add-on publishes to its own image repository."""
+    seen = {}
+    for slug, config in addons.items():
+        image = config.get("image")
+        if not image:
+            continue
+        # Prod pointed at the beta image repository for eight months in 2025
+        # because both folders build identical code, so the mislabelled image
+        # worked and nobody noticed.
+        if image in seen:
+            errors.append(
+                f"{slug} and {seen[image]} both publish to {image}"
+            )
+        seen[image] = slug
+
+
+def main():
+    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else ".")
+    addons = load_addons(root)
+
+    if not addons:
+        print(f"No add-on config.yaml found under {root.resolve()}", file=sys.stderr)
+        return 1
+
+    errors = []
+    check_mirrored_keys(addons, errors)
+    check_versions(addons, errors)
+    check_images(addons, errors)
+
+    if errors:
+        print("Add-on consistency check failed:\n", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"Checked {len(addons)} add-on(s): {', '.join(sorted(addons))} - all consistent.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,105 @@
+"""Shared fixtures.
+
+The add-on script is imported from `gpsd2mqtt_beta/`, which is the source of truth --
+`gpsd2mqtt/` is a copy produced by `gpsd2mqtt_beta/rsync.sh` and must never be edited
+directly. Tests live at the repository root rather than inside either add-on so that
+rsync does not duplicate them into the release folder.
+"""
+
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+ADDON_SOURCE = REPO_ROOT / "gpsd2mqtt_beta"
+
+# Prepended, not appended: the prod add-on directory is also named `gpsd2mqtt`, and
+# being first means the module file always wins over the directory.
+sys.path.insert(0, str(ADDON_SOURCE))
+
+import gpsd2mqtt  # noqa: E402
+
+
+@pytest.fixture
+def module():
+    """The add-on module under test."""
+    return gpsd2mqtt
+
+
+class FakePublish:
+    """One recorded call to `client.publish()`."""
+
+    def __init__(self, topic, payload, retain):
+        self.topic = topic
+        self.payload = payload
+        self.retain = retain
+
+    def json(self):
+        import json
+
+        return json.loads(self.payload)
+
+    def __repr__(self):
+        return f"FakePublish(topic={self.topic!r}, retain={self.retain!r})"
+
+
+class FakeClient:
+    """Stands in for a paho MQTT client, recording what was published."""
+
+    def __init__(self):
+        self.published = []
+        self.subscribed = []
+        self.will = None
+
+    def publish(self, topic, payload=None, qos=0, retain=False):
+        self.published.append(FakePublish(topic, payload, retain))
+
+    def subscribe(self, topic):
+        self.subscribed.append(topic)
+
+    def will_set(self, topic, payload=None, qos=0, retain=False):
+        self.will = FakePublish(topic, payload, retain)
+
+    def topics(self):
+        return [call.topic for call in self.published]
+
+    def for_topic(self, topic):
+        return [call for call in self.published if call.topic == topic]
+
+
+@pytest.fixture
+def client():
+    return FakeClient()
+
+
+@pytest.fixture
+def topics(module):
+    return module.Topics.for_device("abc12345")
+
+
+def make_config(module, **overrides):
+    """Build a Config without going through options.json."""
+    defaults = dict(
+        device="/dev/ttyS0",
+        baudrate=9600,
+        mqtt_broker="core-mosquitto",
+        mqtt_port=1883,
+        mqtt_username="user",
+        mqtt_password="pass",
+        publish_3d_fix_only=True,
+        min_n_satellites=0,
+        publish_interval=10,
+        summary_interval=120,
+        debug=False,
+    )
+    defaults.update(overrides)
+    return module.Config(**defaults)
+
+
+@pytest.fixture
+def config_factory(module):
+    def factory(**overrides):
+        return make_config(module, **overrides)
+
+    return factory

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,11 @@
+# Test-only dependencies. Pinned so a CI run and a local run agree.
+#
+# paho-mqtt and gpsdclient are pinned to the versions the add-on image actually
+# ships (see gpsd2mqtt_beta/Dockerfile) -- gpsd2mqtt.py imports both at module
+# level, so they have to be importable for the tests to collect at all.
+paho-mqtt==1.6.1
+gpsdclient==1.3.2
+
+pytest==9.1.1
+ruff==0.16.1
+PyYAML==6.0.3

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,136 @@
+"""Option parsing.
+
+Three of these encode bugs fixed in 2026.8.0: a password containing spaces was
+truncated, the password was written to the log at debug level, and `publish_interval: 0`
+was silently replaced by the default.
+"""
+
+import json
+import logging
+
+
+def write_options(tmp_path, options):
+    path = tmp_path / "options.json"
+    path.write_text(json.dumps(options))
+    return path
+
+
+def test_publish_interval_zero_is_preserved(module, tmp_path):
+    """0 means "publish every update" and must survive; `or` would swallow it."""
+    path = write_options(tmp_path, {"device": "/dev/ttyS0", "publish_interval": 0})
+
+    config = module.Config.load(path)
+
+    assert config.publish_interval == 0
+
+
+def test_publish_interval_defaults_when_absent(module, tmp_path):
+    path = write_options(tmp_path, {"device": "/dev/ttyS0"})
+
+    config = module.Config.load(path)
+
+    assert config.publish_interval == 10
+
+
+def test_defaults_are_applied(module, tmp_path):
+    path = write_options(tmp_path, {"device": "/dev/ttyS0"})
+
+    config = module.Config.load(path)
+
+    assert config.baudrate == 9600
+    assert config.mqtt_broker == "core-mosquitto"
+    assert config.mqtt_port == 1883
+    assert config.summary_interval == 120
+    assert config.min_n_satellites == 0
+    assert config.publish_3d_fix_only is True
+    assert config.debug is False
+
+
+def test_configured_values_win_over_defaults(module, tmp_path):
+    path = write_options(
+        tmp_path,
+        {
+            "device": "/dev/ttyUSB0",
+            "baudrate": 38400,
+            "mqtt_broker": "192.168.1.10",
+            "mqtt_port": 8883,
+            "min_n_satellites": 7,
+            "summary_interval": 300,
+            "publish_3d_fix_only": False,
+            "debug": True,
+        },
+    )
+
+    config = module.Config.load(path)
+
+    assert config.device == "/dev/ttyUSB0"
+    assert config.baudrate == 38400
+    assert config.mqtt_broker == "192.168.1.10"
+    assert config.mqtt_port == 8883
+    assert config.min_n_satellites == 7
+    assert config.summary_interval == 300
+    assert config.publish_3d_fix_only is False
+    assert config.debug is True
+
+
+def test_environment_credentials_win_over_options(module, tmp_path, monkeypatch):
+    """run.sh resolves Home Assistant's integrated credentials and exports them."""
+    monkeypatch.setenv("MQTT_USER", "from-env")
+    monkeypatch.setenv("MQTT_PASSWORD", "env-secret")
+    path = write_options(
+        tmp_path,
+        {"device": "/dev/ttyS0", "mqtt_username": "from-file", "mqtt_pw": "file-secret"},
+    )
+
+    config = module.Config.load(path)
+
+    assert config.mqtt_username == "from-env"
+    assert config.mqtt_password == "env-secret"
+
+
+def test_options_credentials_used_when_environment_is_empty(module, tmp_path, monkeypatch):
+    monkeypatch.delenv("MQTT_USER", raising=False)
+    monkeypatch.delenv("MQTT_PASSWORD", raising=False)
+    path = write_options(
+        tmp_path,
+        {"device": "/dev/ttyS0", "mqtt_username": "manual", "mqtt_pw": "manual-secret"},
+    )
+
+    config = module.Config.load(path)
+
+    assert config.mqtt_username == "manual"
+    assert config.mqtt_password == "manual-secret"
+
+
+def test_password_with_spaces_survives_intact(module, tmp_path, monkeypatch):
+    """Passing credentials via argv used to split this into separate arguments."""
+    monkeypatch.setenv("MQTT_USER", "user")
+    monkeypatch.setenv("MQTT_PASSWORD", "two words and more")
+    path = write_options(tmp_path, {"device": "/dev/ttyS0"})
+
+    config = module.Config.load(path)
+
+    assert config.mqtt_password == "two words and more"
+
+
+def test_missing_credentials_become_empty_strings(module, tmp_path, monkeypatch):
+    monkeypatch.delenv("MQTT_USER", raising=False)
+    monkeypatch.delenv("MQTT_PASSWORD", raising=False)
+    path = write_options(tmp_path, {"device": "/dev/ttyS0"})
+
+    config = module.Config.load(path)
+
+    assert config.mqtt_username == ""
+    assert config.mqtt_password == ""
+
+
+def test_log_options_never_logs_the_password(module, config_factory, caplog):
+    config = config_factory(mqtt_password="hunter2-should-never-appear")
+
+    with caplog.at_level(logging.DEBUG, logger="gpsd2mqtt"):
+        config.log_options()
+
+    assert caplog.text, "expected log_options to emit something at debug level"
+    assert "hunter2-should-never-appear" not in caplog.text
+    # The username is fine to log, and confirms the fixture really ran.
+    assert config.mqtt_username in caplog.text

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -1,0 +1,249 @@
+"""What actually goes onto the broker.
+
+The retain assertions here are the important ones. Retained discovery configs outlive
+the add-on: uninstall it and the broker keeps serving the config, so Home Assistant
+recreates a permanently unavailable device on every restart until someone hand-clears
+the topic. Re-announcing on `homeassistant/status` covers the restart case instead.
+"""
+
+import json
+
+# --- discovery -------------------------------------------------------------
+
+
+def test_discovery_configs_are_not_retained(module, client, topics):
+    module.publish_discovery(client, topics, "abc12345")
+
+    for topic in (topics.config, topics.sky_config):
+        calls = client.for_topic(topic)
+        assert len(calls) == 1, f"expected exactly one publish to {topic}"
+        assert calls[0].retain is False, (
+            f"{topic} must not be retained -- a retained discovery config orphans "
+            "the entity when the add-on is uninstalled"
+        )
+
+
+def test_deprecated_topic_is_cleared_with_an_empty_retained_payload(
+    module, client, topics
+):
+    """The one legitimate retain: an empty retained payload deletes a retained message."""
+    module.publish_discovery(client, topics, "abc12345")
+
+    calls = client.for_topic(module.DEPRECATED_CONFIG_TOPIC)
+
+    assert len(calls) == 1
+    assert calls[0].retain is True
+    assert calls[0].payload == "", (
+        "must be an empty payload -- a non-empty retained payload would create "
+        "exactly the orphan this is meant to remove"
+    )
+
+
+def test_discovery_payloads_describe_both_entities(module, client, topics):
+    module.publish_discovery(client, topics, "abc12345")
+
+    tracker = client.for_topic(topics.config)[0].json()
+    sky = client.for_topic(topics.sky_config)[0].json()
+
+    assert tracker["unique_id"] == "abc12345"
+    assert tracker["json_attributes_topic"] == topics.attr
+    assert tracker["object_id"] == "gps_location"
+
+    assert sky["unique_id"] == "abc12345_sky"
+    assert sky["state_topic"] == topics.sky_state
+    assert sky["json_attributes_topic"] == topics.sky_attr
+
+
+def test_both_entities_share_one_device(module, client, topics):
+    """Otherwise they appear as two unrelated devices in Home Assistant."""
+    module.publish_discovery(client, topics, "abc12345")
+
+    tracker = client.for_topic(topics.config)[0].json()
+    sky = client.for_topic(topics.sky_config)[0].json()
+
+    assert tracker["device"]["identifiers"] == "gpsd2mqtt_abc12345"
+    assert sky["device"]["identifiers"] == tracker["device"]["identifiers"]
+
+
+def test_discovery_payloads_are_valid_json(module, client, topics):
+    module.publish_discovery(client, topics, "abc12345")
+
+    for call in client.published:
+        if call.payload:
+            json.loads(call.payload)
+
+
+# --- SKY -------------------------------------------------------------------
+
+
+def test_sky_publishes_satellite_count_as_state(module, client, topics, config_factory):
+    stats = module.Stats()
+    report = {"class": "SKY", "uSat": 9, "nSat": 14}
+
+    module.handle_sky(
+        client, topics, report, config_factory(), module.Throttle(0), stats
+    )
+
+    assert client.for_topic(topics.sky_state)[0].payload == "9"
+    assert client.for_topic(topics.sky_attr)[0].json()["uSat"] == 9
+
+
+def test_sky_updates_are_throttled(module, client, topics, config_factory):
+    """The 2026.8.0 bug: SKY ignored publish_interval entirely."""
+    stats = module.Stats()
+    throttle = module.Throttle(3600)
+    config = config_factory()
+
+    for _ in range(5):
+        module.handle_sky(
+            client, topics, {"class": "SKY", "uSat": 9}, config, throttle, stats
+        )
+
+    assert client.for_topic(topics.sky_state) == []
+
+
+def test_sky_tracks_the_best_satellite_count(module, client, topics, config_factory):
+    stats = module.Stats()
+    config = config_factory()
+
+    for count in (4, 11, 7):
+        module.handle_sky(
+            client, topics, {"class": "SKY", "uSat": count}, config,
+            module.Throttle(0), stats,
+        )
+
+    assert stats.max_satellites == 11
+
+
+def test_sky_gates_position_on_the_satellite_requirement(
+    module, client, topics, config_factory
+):
+    config = config_factory(min_n_satellites=6)
+    stats = module.Stats()
+
+    too_few = module.handle_sky(
+        client, topics, {"class": "SKY", "uSat": 4}, config, module.Throttle(0), stats
+    )
+    enough = module.handle_sky(
+        client, topics, {"class": "SKY", "uSat": 6}, config, module.Throttle(0), stats
+    )
+
+    assert too_few is False
+    assert enough is True
+
+
+def test_sky_gate_is_open_when_no_requirement_is_set(
+    module, client, topics, config_factory
+):
+    stats = module.Stats()
+
+    allowed = module.handle_sky(
+        client, topics, {"class": "SKY", "uSat": 0}, config_factory(min_n_satellites=0),
+        module.Throttle(0), stats,
+    )
+
+    assert allowed is True
+
+
+# --- TPV -------------------------------------------------------------------
+
+
+def test_tpv_publishes_a_normalised_position(module, client, topics, config_factory):
+    stats = module.Stats()
+    report = {"class": "TPV", "mode": 3, "lat": 59.9, "lon": 10.7}
+
+    module.handle_tpv(
+        client, topics, report, config_factory(), module.Throttle(0), stats
+    )
+
+    published = client.for_topic(topics.attr)[0].json()
+    assert published["latitude"] == 59.9
+    assert published["longitude"] == 10.7
+    assert published["accuracy"] == "3D fix"
+    assert stats.published_updates == 1
+
+
+def test_tpv_position_updates_are_not_retained(module, client, topics, config_factory):
+    module.handle_tpv(
+        client, topics, {"class": "TPV", "mode": 3, "lat": 1.0, "lon": 2.0},
+        config_factory(), module.Throttle(0), module.Stats(),
+    )
+
+    assert client.for_topic(topics.attr)[0].retain is False
+
+
+def test_tpv_withholds_a_poor_fix_by_default(module, client, topics, config_factory):
+    stats = module.Stats()
+
+    for mode in (1, 2):
+        module.handle_tpv(
+            client, topics, {"class": "TPV", "mode": mode, "lat": 1.0, "lon": 2.0},
+            config_factory(publish_3d_fix_only=True), module.Throttle(0), stats,
+        )
+
+    assert client.for_topic(topics.attr) == []
+    assert stats.published_updates == 0
+
+
+def test_tpv_publishes_a_poor_fix_when_the_user_opts_in(
+    module, client, topics, config_factory
+):
+    stats = module.Stats()
+
+    module.handle_tpv(
+        client, topics, {"class": "TPV", "mode": 2, "lat": 1.0, "lon": 2.0},
+        config_factory(publish_3d_fix_only=False), module.Throttle(0), stats,
+    )
+
+    assert len(client.for_topic(topics.attr)) == 1
+
+
+def test_tpv_records_accuracy_even_when_the_update_is_withheld(
+    module, client, topics, config_factory
+):
+    """The summary should still report what was achieved, not stay blank."""
+    stats = module.Stats()
+
+    module.handle_tpv(
+        client, topics, {"class": "TPV", "mode": 2, "lat": 1.0, "lon": 2.0},
+        config_factory(publish_3d_fix_only=True), module.Throttle(0), stats,
+    )
+
+    assert stats.accuracy == "2D fix"
+
+
+def test_tpv_updates_are_throttled(module, client, topics, config_factory):
+    stats = module.Stats()
+    throttle = module.Throttle(3600)
+    config = config_factory()
+
+    for _ in range(5):
+        module.handle_tpv(
+            client, topics, {"class": "TPV", "mode": 3, "lat": 1.0, "lon": 2.0},
+            config, throttle, stats,
+        )
+
+    assert client.for_topic(topics.attr) == []
+
+
+def test_a_withheld_poor_fix_does_not_consume_the_throttle(
+    module, client, topics, config_factory
+):
+    """A 2D fix must not reset the clock and delay the 3D fix that follows it."""
+    stats = module.Stats()
+    throttle = module.Throttle(0.01)
+    config = config_factory(publish_3d_fix_only=True)
+
+    import time
+
+    time.sleep(0.05)
+    module.handle_tpv(
+        client, topics, {"class": "TPV", "mode": 2, "lat": 1.0, "lon": 2.0},
+        config, throttle, stats,
+    )
+    module.handle_tpv(
+        client, topics, {"class": "TPV", "mode": 3, "lat": 1.0, "lon": 2.0},
+        config, throttle, stats,
+    )
+
+    assert len(client.for_topic(topics.attr)) == 1

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,181 @@
+"""Report transformation, topic naming, throttling and the summary line."""
+
+import logging
+import time
+
+# --- normalise_tpv ---------------------------------------------------------
+
+
+def test_gpsd_fields_are_renamed_for_home_assistant(module):
+    report = {"class": "TPV", "mode": 3, "lat": 59.9, "lon": 10.7, "alt": 12.5}
+
+    result = module.normalise_tpv(report)
+
+    assert result["latitude"] == 59.9
+    assert result["longitude"] == 10.7
+    assert result["altitude"] == 12.5
+    # The gpsd names must be gone, or Home Assistant sees duplicate attributes.
+    assert "lat" not in result
+    assert "lon" not in result
+    assert "alt" not in result
+
+
+def test_absent_position_fields_are_not_invented(module):
+    report = {"class": "TPV", "mode": 1}
+
+    result = module.normalise_tpv(report)
+
+    assert "latitude" not in result
+    assert "longitude" not in result
+    assert "altitude" not in result
+
+
+def test_track_and_magtrack_are_published_as_null_when_absent(module):
+    """gpsd stops sending these when stationary; explicit null stops HA expiring them."""
+    report = {"class": "TPV", "mode": 3, "lat": 1.0, "lon": 2.0}
+
+    result = module.normalise_tpv(report)
+
+    assert result["track"] is None
+    assert result["magtrack"] is None
+
+
+def test_track_and_magtrack_are_preserved_when_present(module):
+    report = {"class": "TPV", "mode": 3, "track": 187.4, "magtrack": 185.1}
+
+    result = module.normalise_tpv(report)
+
+    assert result["track"] == 187.4
+    assert result["magtrack"] == 185.1
+
+
+def test_mode_is_translated_to_a_readable_accuracy(module):
+    assert module.normalise_tpv({"mode": 1})["accuracy"] == "No fix"
+    assert module.normalise_tpv({"mode": 2})["accuracy"] == "2D fix"
+    assert module.normalise_tpv({"mode": 3})["accuracy"] == "3D fix"
+
+
+def test_unknown_mode_is_reported_as_unknown(module):
+    assert module.normalise_tpv({})["accuracy"] == "Unknown"
+    assert module.normalise_tpv({"mode": 0})["accuracy"] == "Unknown"
+
+
+# --- Topics ----------------------------------------------------------------
+
+
+def test_topic_names_are_stable(module):
+    """These strings are a contract: changing one orphans every existing entity."""
+    topics = module.Topics.for_device("abc12345")
+
+    assert topics.config == "homeassistant/device_tracker/gpsd2mqtt/abc12345/config"
+    assert topics.attr == "gpsd2mqtt/abc12345/attribute"
+    assert topics.sky_config == "homeassistant/sensor/gpsd2mqtt/abc12345_sky/config"
+    assert topics.sky_state == "gpsd2mqtt/abc12345_sky/state"
+    assert topics.sky_attr == "gpsd2mqtt/abc12345_sky/attribute"
+
+
+def test_unique_identifier_is_stable_and_short(module):
+    first = module.get_unique_identifier()
+    second = module.get_unique_identifier()
+
+    assert first == second
+    assert len(first) == 8
+
+
+# --- Throttle --------------------------------------------------------------
+
+
+def test_zero_interval_disables_throttling(module):
+    throttle = module.Throttle(0)
+
+    assert throttle.ready()
+    throttle.mark()
+    assert throttle.ready(), "interval 0 means publish every update"
+
+
+def test_throttle_withholds_until_the_interval_has_passed(module):
+    throttle = module.Throttle(3600)
+
+    throttle.mark()
+
+    assert not throttle.ready()
+
+
+def test_throttle_becomes_ready_after_the_interval(module):
+    throttle = module.Throttle(0.01)
+
+    throttle.mark()
+    time.sleep(0.05)
+
+    assert throttle.ready()
+
+
+def test_throttles_are_independent(module):
+    """SKY and TPV share an interval but must not share a clock.
+
+    Before 2026.8.0 a single timestamp was used for both, so SKY updates were only
+    rate-limited when a TPV update happened to reset it -- and streamed unthrottled
+    whenever TPV was being withheld by the satellite requirement.
+    """
+    sky = module.Throttle(0.01)
+    tpv = module.Throttle(0.01)
+
+    time.sleep(0.05)
+    assert sky.ready() and tpv.ready()
+
+    sky.mark()
+
+    assert not sky.ready()
+    assert tpv.ready(), "marking one throttle must not affect the other"
+
+
+# --- Stats -----------------------------------------------------------------
+
+
+def test_summary_omits_the_requirement_when_none_is_configured(
+    module, config_factory, caplog
+):
+    """"of required 0 GPS satellites" was noise; fixed in 2026.8.0."""
+    stats = module.Stats(published_updates=4, max_satellites=9, accuracy="3D fix")
+
+    with caplog.at_level(logging.INFO, logger="gpsd2mqtt"):
+        stats.emit(config_factory(min_n_satellites=0))
+
+    assert "required" not in caplog.text
+    assert "9 GPS satellites" in caplog.text
+
+
+def test_summary_reports_the_requirement_when_it_is_met(module, config_factory, caplog):
+    stats = module.Stats(published_updates=4, max_satellites=9, accuracy="3D fix")
+
+    with caplog.at_level(logging.INFO, logger="gpsd2mqtt"):
+        stats.emit(config_factory(min_n_satellites=5))
+
+    assert "9 of required 5" in caplog.text
+    assert "not at configured accuracy" not in caplog.text
+
+
+def test_summary_flags_a_shortfall(module, config_factory, caplog):
+    stats = module.Stats(published_updates=0, max_satellites=2, accuracy="2D fix")
+
+    with caplog.at_level(logging.INFO, logger="gpsd2mqtt"):
+        stats.emit(config_factory(min_n_satellites=6))
+
+    assert "not at configured accuracy" in caplog.text
+    assert "2 of required 6" in caplog.text
+
+
+def test_emit_resets_the_counters(module, config_factory, caplog):
+    stats = module.Stats(published_updates=11, max_satellites=8, accuracy="3D fix")
+
+    with caplog.at_level(logging.INFO, logger="gpsd2mqtt"):
+        stats.emit(config_factory())
+
+    assert stats.published_updates == 0
+    assert stats.max_satellites == 0
+
+
+def test_summary_is_not_due_immediately(module):
+    stats = module.Stats()
+
+    assert not stats.due(3600)


### PR DESCRIPTION
Add python tests and linting to CI, replace changed-files action

Replace jitterbit/get-changed-files with a plain git diff in builder.yaml. It is unmaintained and emits set-output deprecation warnings, but the real problem is that it requires the PR head to be a strict descendant of base, which fails after every merge to main. Diffing against the merge base removes that constraint entirely.

Add a 43-test pytest suite at the repository root, importing from gpsd2mqtt_beta since that is the source of truth and rsync would otherwise duplicate the tests into the release folder. Coverage concentrates on the regressions fixed in 2026.8.0: the shared SKY/TPV throttle, publish_interval 0 being swallowed, the password appearing in debug logs, and the unretained discovery configs.

Pin the ruff ruleset in ruff.toml so CI and local runs agree.

Add scripts/check_addons.py to guard the schema mirroring that exclude_list.txt makes necessary. Not yet wired into CI: it currently fails on the leftover mqtt_state option in the prod schema, and is enabled in the same commit that removes it.