### PR TITLE
Robustness batch for 2026.8.1b2

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -38,17 +38,14 @@ jobs:
           set -euo pipefail
 
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            # Diff against the merge base, not the base tip. Comparing to the tip
-            # requires the PR head to be a strict descendant of base, which it is
-            # not after main receives a merge commit that dev never got -- that is
-            # what the previous action failed on.
+            # Merge base, not the base tip: comparing to the tip would require
+            # the PR head to be a strict descendant of base.
             base="$(git merge-base "${PR_BASE_SHA}" "${PR_HEAD_SHA}")"
             head="${PR_HEAD_SHA}"
           else
             base="${PUSH_BEFORE}"
             head="${PUSH_AFTER}"
-            # An all-zero "before" means a new branch or a force push, where there
-            # is no previous state to compare against.
+            # All-zero means a new branch or force push: no previous state.
             if [[ -z "${base}" || "${base}" =~ ^0+$ ]] || ! git cat-file -e "${base}^{commit}" 2>/dev/null; then
               base="${head}^"
             fi
@@ -69,9 +66,7 @@ jobs:
           declare -a changed_addons=()
           for addon in ${{ steps.addons.outputs.addons }}; do
             for file in ${{ env.MONITORED_FILES }}; do
-              # Exact path match. The previous compare was an unanchored regex and
-              # worked only by luck of the directory names. The second grep covers
-              # `rootfs`, which is a directory rather than a file.
+              # Exact path match; the second grep covers rootfs, a directory.
               if grep -qxF "${addon}/${file}" /tmp/changed_files.txt \
                 || grep -qF "${addon}/${file}/" /tmp/changed_files.txt; then
                 changed_addons+=("${addon}")

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,8 +58,7 @@ jobs:
       - name: Ruff
         run: ruff check .
 
-      # Tests import the add-on module from gpsd2mqtt_beta/, which is the source of
-      # truth. gpsd2mqtt/ is a copy produced by rsync.sh and is deliberately not
-      # linted or tested separately.
+      # Tests import from gpsd2mqtt_beta/, the source of truth. gpsd2mqtt/ is an
+      # rsync copy and is not linted or tested separately.
       - name: Pytest
         run: pytest tests/ -v

--- a/gpsd2mqtt_beta/CHANGELOG.md
+++ b/gpsd2mqtt_beta/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [2026.8.1b2] - 2026-08-02
+
+### Added
+- The device tracker and Sky Data sensor now report availability. They show as unavailable when the add-on stops, whether it stops cleanly or crashes, and leave nothing behind on the broker when the add-on is uninstalled
+- A watchdog restarts the add-on if GPSD stops responding. Previously a dead GPSD left the add-on running and apparently healthy
+
+### Fixed
+- Publishing could stall for as long as the system clock was stepped backwards, which happens on installs where GPS is also used as a time source
+- The entities are re-announced when the MQTT broker restarts, so they recover without restarting Home Assistant
+- Wrong MQTT credentials now stop the add-on with a clear error instead of retrying silently forever
+- Stopping the add-on no longer waits out the GPSD retry delay
+- The add-on now gives up and restarts if GPSD produces no data at all for about a minute, instead of retrying indefinitely
+- The log summary no longer reports "0.0 minutes" when the summary interval is under a minute
+
+### Changed
+- GPSD is now installed with a minimum version rather than an exact one, so a routine Alpine update no longer breaks the build at an arbitrary time
+- The AppArmor profile no longer refers to a hardcoded Python version
+- The startup log reports the Python version in use alongside the GPSD version
+
+<details>
+<summary>Older changes</summary>
+
 ## [2026.8.1b1] - 2026-08-02
 
 ### Changed
@@ -7,9 +29,6 @@
 
 ### Added
 - Automated tests and linting now run on every pull request, covering option parsing, GPS report transformation, publish throttling and the MQTT discovery payloads. Test code is not part of the add-on image
-
-<details>
-<summary>Older changes</summary>
 
 ## [2026.8.0b2] - 2026-08-01
 

--- a/gpsd2mqtt_beta/CHANGELOG.md
+++ b/gpsd2mqtt_beta/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - The device tracker and Sky Data sensor now report availability. They show as unavailable when the add-on stops, whether it stops cleanly or crashes, and leave nothing behind on the broker when the add-on is uninstalled
-- A watchdog restarts the add-on if GPSD stops responding. Previously a dead GPSD left the add-on running and apparently healthy
+- The add-on now reports itself unhealthy when GPSD stops responding, so enabling **Watchdog** on the Info tab restarts it automatically. Previously a dead GPSD left the add-on running and apparently healthy
 
 ### Fixed
 - Publishing could stall for as long as the system clock was stepped backwards, which happens on installs where GPS is also used as a time source

--- a/gpsd2mqtt_beta/DEVELOPMENT.md
+++ b/gpsd2mqtt_beta/DEVELOPMENT.md
@@ -109,6 +109,23 @@ Newest entry visible, everything older folded into one `<details>` block:
 Use only the sections you need. Versions are calendar-based: `YYYY.M.P`, with
 betas adding `bN`.
 
+## Version numbers
+
+The month is the month of *release*, and the beta number names the prod release it
+will **become** — not the one already shipped. So after `2026.8.0` goes out, the
+next beta cycle opens at `2026.8.1b1` and promotes to `2026.8.1`. If a cycle slips
+into the next month, both numbers move together.
+
+The release tag is the `version:` string verbatim, so the format here is the format
+on the releases page. Two consequences:
+
+- **Do not zero-pad the month.** `2026.8.1`, not `2026.08.1`. The `2026.08.0` tag is
+  a one-off from before releases were automated; it is left alone because it is
+  published, but nothing should match it.
+- **No two add-ons may share a version.** Tags are repository-wide, so a collision
+  would silently skip the second release. The `bN` suffix is what keeps beta and
+  prod apart, and `scripts/check_addons.py` enforces all of this in CI.
+
 **The changelog is the source of truth for GitHub releases.**
 `.github/workflows/release.yaml` watches `main` for a changed `version:` in any
 add-on's `config.yaml`. When it sees one it creates the GitHub release: tag and
@@ -126,19 +143,24 @@ Two things follow from this:
 
 Nothing is ever committed back to `main` by CI.
 
-## Upgrading GPSD
+## Pinning policy
 
-`gpsd` is pinned to an exact version from the Alpine **edge** repository,
-because Alpine stable lags behind. Edge is a rolling repository, so the pinned
-version eventually disappears and the build fails at `apk add` with "unable to
-select packages". That failure is the signal to bump the pin.
+Keep pins and repository overrides to a minimum, and stay on standard Alpine
+releases wherever possible. Every pin is something that rots later. What exists
+today, and what would remove it:
 
-Check what edge currently has:
-https://pkgs.alpinelinux.org/packages?name=gpsd&branch=edge&repo=main
+| Pin | Why it exists | How it goes away |
+|---|---|---|
+| `gpsd>=3.27.1` from **edge** | Stable is on 3.26.1, which has CVE-2025-67268 and CVE-2025-67269 | Alpine stable reaching 3.27.1; then drop the `--repository` override too |
+| `py3-paho-mqtt<2` | `gpsd2mqtt.py` uses the v1 callback signatures | Migrating to the 2.x `CallbackAPIVersion` API |
+| `gpsdclient==1.3.2` (pip) | No Alpine package exists | An Alpine package appearing |
 
-Update both `gpsd` and `gpsd-clients` in `gpsd2mqtt_beta/Dockerfile` to the same
-version. `run.sh` logs `gpsd --version` at startup, so the add-on log confirms
-which version is actually running.
+Python is **not** pinned — it follows the Alpine base image, so nothing may
+hardcode a python minor version. `run.sh` logs both the python and gpsd versions
+at startup, so the add-on log shows what is actually running.
+
+Check what Alpine currently ships:
+https://pkgs.alpinelinux.org/packages?name=gpsd&repo=main
 
 ## Verifying a release
 

--- a/gpsd2mqtt_beta/DOCS.md
+++ b/gpsd2mqtt_beta/DOCS.md
@@ -128,9 +128,10 @@ entities simply disappear rather than lingering as permanently unavailable.
 The add-on restarts itself when things go wrong, rather than sitting there looking
 healthy:
 
-- If gpsd stops responding, Home Assistant's watchdog notices port 2947 has gone
-  quiet and restarts the add-on. The add-on also gives up on its own after about a
-  minute without any GPS data.
+- If gpsd stops responding, the add-on reports itself unhealthy. Enable
+  **Watchdog** on the add-on's Info tab and Home Assistant will restart it. The
+  add-on also gives up on its own after about a minute without any GPS data, which
+  restarts it the same way.
 - If the MQTT broker restarts, the add-on reconnects and re-announces its entities
   automatically. No Home Assistant restart is needed.
 - If the MQTT credentials are wrong, the add-on stops with a clear error in the log
@@ -173,9 +174,10 @@ improve the receiver's view of the sky. A cold start can take several minutes.
 broker. Check the add-on log — if it stopped on an MQTT error, the reason is the
 last line.
 
-**The add-on keeps restarting.** The watchdog restarts it when gpsd stops
-answering. Look for gpsd's own startup errors near the top of the log; the usual
-cause is a serial device that is missing, or is held open by something else.
+**The add-on keeps restarting.** With **Watchdog** enabled, Home Assistant
+restarts it whenever gpsd stops answering. Look for gpsd's own startup errors near
+the top of the log; the usual cause is a serial device that is missing, or is held
+open by something else.
 
 **The add-on cannot open the serial device.** Make sure no other add-on or
 integration (such as the GPSD integration) is holding the same device.

--- a/gpsd2mqtt_beta/DOCS.md
+++ b/gpsd2mqtt_beta/DOCS.md
@@ -114,6 +114,28 @@ as `null` when stationary so Home Assistant does not expire the attributes.
 **`sensor.gpsd_service_sky_data`** — the number of satellites currently used for
 the fix, with the full gpsd SKY report as attributes.
 
+### Availability
+
+Both entities go **unavailable** when the add-on stops, rather than keeping their
+last position indefinitely. This covers a clean stop as well as a crash or a lost
+connection — in the latter case the broker publishes it on the add-on's behalf.
+
+Nothing is retained on the broker, so uninstalling the add-on leaves no trace: the
+entities simply disappear rather than lingering as permanently unavailable.
+
+### Recovery
+
+The add-on restarts itself when things go wrong, rather than sitting there looking
+healthy:
+
+- If gpsd stops responding, Home Assistant's watchdog notices port 2947 has gone
+  quiet and restarts the add-on. The add-on also gives up on its own after about a
+  minute without any GPS data.
+- If the MQTT broker restarts, the add-on reconnects and re-announces its entities
+  automatically. No Home Assistant restart is needed.
+- If the MQTT credentials are wrong, the add-on stops with a clear error in the log
+  instead of retrying silently forever.
+
 ## Example: keep the home zone on your actual position
 
 ```yaml
@@ -146,6 +168,14 @@ discovery has been sent.
 **Position never updates.** Check the summary line in the log. If it reports
 fewer satellites than required, either lower **Required number of satellites** or
 improve the receiver's view of the sky. A cold start can take several minutes.
+
+**Entities show as unavailable.** The add-on is not running, or cannot reach the
+broker. Check the add-on log — if it stopped on an MQTT error, the reason is the
+last line.
+
+**The add-on keeps restarting.** The watchdog restarts it when gpsd stops
+answering. Look for gpsd's own startup errors near the top of the log; the usual
+cause is a serial device that is missing, or is held open by something else.
 
 **The add-on cannot open the serial device.** Make sure no other add-on or
 integration (such as the GPSD integration) is holding the same device.

--- a/gpsd2mqtt_beta/Dockerfile
+++ b/gpsd2mqtt_beta/Dockerfile
@@ -26,4 +26,10 @@ COPY gpsd2mqtt.py /
 
 RUN chmod a+x /run.sh /gpsd2mqtt.py
 
+# Reports the container unhealthy when gpsd stops answering, which the Supervisor
+# acts on when the add-on's Watchdog option is enabled. start-period covers gpsd
+# and the first fix.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD python3 -c "import socket; socket.create_connection(('127.0.0.1', 2947), 3)" || exit 1
+
 CMD [ "/run.sh" ]

--- a/gpsd2mqtt_beta/Dockerfile
+++ b/gpsd2mqtt_beta/Dockerfile
@@ -1,24 +1,21 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-# py3-paho-mqtt is constrained to 1.x on purpose: gpsd2mqtt.py uses the v1
-# callback signatures, and paho-mqtt 2.x makes a bare mqtt.Client() raise
-# ValueError (it requires an explicit CallbackAPIVersion). Alpine still ships
-# 1.6.x, so this constraint is a no-op today and a guard for when it bumps.
+# Python is unpinned and follows the Alpine base, so nothing may hardcode a
+# python minor version. run.sh logs the version at startup.
+#
+# paho-mqtt is held below 2.x: gpsd2mqtt.py uses the v1 callback signatures, and
+# 2.x requires an explicit CallbackAPIVersion.
 RUN apk add --no-cache bash py3-pip "py3-paho-mqtt<2" py3-pyserial
 
-# gpsd comes from the edge repository because Alpine stable lags behind.
-# 3.27.3 picks up the 3.27.1 security fixes (CVE-2025-67268 heap out-of-bounds
-# write in NMEA2000 parsing, CVE-2025-67269 integer underflow in NovAtel packet
-# handling).
+# gpsd comes from edge because stable is still on 3.26.1. The floor is 3.27.1,
+# which carries the CVE-2025-67268 and CVE-2025-67269 fixes.
 #
-# NOTE: edge is a rolling repository, so this exact pin has a shelf life -- once
-# edge moves past 3.27.3-r1 the version disappears and this line fails at build
-# time with "unable to select packages". That build failure is the signal to
-# come back and bump the pin. Check the current version at:
-# https://pkgs.alpinelinux.org/packages?name=gpsd&branch=edge&repo=main
+# A minimum rather than an exact version: edge is rolling, so an exact pin
+# disappears and breaks the build at an arbitrary time. Revisit once Alpine
+# stable reaches 3.27.1 and this override can be dropped entirely.
 RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main \
-    gpsd=3.27.3-r1 gpsd-clients=3.27.3-r1
+    "gpsd>=3.27.1" "gpsd-clients>=3.27.1"
 
 # Pinned so image builds stay reproducible.
 RUN pip install --break-system-packages gpsdclient==1.3.2

--- a/gpsd2mqtt_beta/apparmor.txt
+++ b/gpsd2mqtt_beta/apparmor.txt
@@ -67,10 +67,5 @@ profile gpsd2mqtt flags=(attach_disconnected,mediate_deleted) {
     # Allow system calls needed for gpsd
     capability setgid,
     capability setuid,
-
-    # Add any additional MQTT-related rules if needed
-    # For example, if you're using the paho-mqtt library
-    /usr/bin/python3 cx -> paho.mqtt,
-    /usr/lib/python3.11/site-packages/paho/mqtt/** r,
   }
 }

--- a/gpsd2mqtt_beta/config.yaml
+++ b/gpsd2mqtt_beta/config.yaml
@@ -5,7 +5,7 @@ description: >-
 
   Installation requires you to set up a username and password to publish to MQTT. Also you must select the serial device for GPSD in configuration.
 url: https://github.com/corvy/ha-addons/tree/main/gpsd2mqtt_beta
-version: "2026.8.1b1"
+version: "2026.8.1b2"
 slug: "gpsd2mqtt_beta"
 init: false
 # Development channel for gpsd2mqtt. Not intended for general use -- install the
@@ -41,6 +41,10 @@ schema:
   debug: bool?
 ports:
   2947/tcp: null
+# Restarts the add-on when gpsd stops answering; nothing else supervises it.
+# Reaches the container address regardless of the port mapping above, which is
+# why gpsd always runs with --listenany.
+watchdog: tcp://[HOST]:2947
 devices:
   - /dev/pps0
 image: ghcr.io/corvy/{arch}-addon-gpsd2mqtt-beta

--- a/gpsd2mqtt_beta/config.yaml
+++ b/gpsd2mqtt_beta/config.yaml
@@ -41,10 +41,6 @@ schema:
   debug: bool?
 ports:
   2947/tcp: null
-# Restarts the add-on when gpsd stops answering; nothing else supervises it.
-# Reaches the container address regardless of the port mapping above, which is
-# why gpsd always runs with --listenany.
-watchdog: tcp://[HOST]:2947
 devices:
   - /dev/pps0
 image: ghcr.io/corvy/{arch}-addon-gpsd2mqtt-beta

--- a/gpsd2mqtt_beta/gpsd2mqtt.py
+++ b/gpsd2mqtt_beta/gpsd2mqtt.py
@@ -7,7 +7,6 @@ coverage.
 """
 
 import dataclasses
-import datetime
 import hashlib
 import json
 import logging
@@ -31,9 +30,32 @@ DEPRECATED_CONFIG_TOPIC = "homeassistant/device_tracker/gpsd/config"
 RECONNECT_MIN_DELAY = 5
 RECONNECT_MAX_DELAY = 300
 
-# Pause before reopening the gpsd stream after it drops, so a gpsd that is down
-# does not spin this loop at full speed.
+# Availability payloads. "offline" is also registered as the last will.
+PAYLOAD_ONLINE = "online"
+PAYLOAD_OFFLINE = "offline"
+
+# CONNACK codes that retrying cannot fix; the configuration has to change.
+FATAL_CONNECT_CODES = {
+    4: "bad username or password",
+    5: "not authorised",
+}
+
+# Seconds to wait for the broker before giving up and exiting non-zero.
+CONNECT_TIMEOUT = 120
+
+# Grace for the final "offline" publish to reach the socket before shutdown.
+SHUTDOWN_PUBLISH_TIMEOUT = 2
+
+# Pause before reopening the gpsd stream, so a dead gpsd does not spin the loop.
 GPSD_RETRY_DELAY = 5
+
+# Hang-breaker, not a poll interval. gpsd emits about once a second, so this
+# only fires when gpsd is wedged. A timeout ends the stream rather than pausing
+# it: gpsdclient reads through makefile(), whose buffer is undefined after one.
+GPSD_STREAM_TIMEOUT = 30
+
+# Consecutive gpsd sessions yielding no reports before treating gpsd as gone.
+MAX_BARREN_SESSIONS = 12
 
 # gpsd TPV "mode" values, see https://gpsd.gitlab.io/gpsd/gpsd_json.html
 FIX_MODES = {1: "No fix", 2: "2D fix", 3: "3D fix"}
@@ -112,6 +134,7 @@ class Topics:
     sky_config: str
     sky_state: str
     sky_attr: str
+    availability: str
 
     @classmethod
     def for_device(cls, unique_id):
@@ -121,23 +144,28 @@ class Topics:
             sky_config=f"homeassistant/sensor/gpsd2mqtt/{unique_id}_sky/config",
             sky_state=f"gpsd2mqtt/{unique_id}_sky/state",
             sky_attr=f"gpsd2mqtt/{unique_id}_sky/attribute",
+            availability=f"gpsd2mqtt/{unique_id}/availability",
         )
 
 
 class Throttle:
-    """Rate limiter for publishing. An interval of 0 disables throttling."""
+    """Rate limiter for publishing. An interval of 0 disables throttling.
+
+    Monotonic: chrony, often fed by gpsd itself, steps the system clock, and a
+    backwards step would withhold every update until real time caught up.
+    """
 
     def __init__(self, interval):
         self._interval = interval
-        self._last = datetime.datetime.now()
+        self._last = time.monotonic()
 
     def ready(self):
         if self._interval == 0:
             return True
-        return (datetime.datetime.now() - self._last).total_seconds() >= self._interval
+        return time.monotonic() - self._last >= self._interval
 
     def mark(self):
-        self._last = datetime.datetime.now()
+        self._last = time.monotonic()
 
 
 @dataclasses.dataclass
@@ -146,20 +174,21 @@ class Stats:
 
     published_updates: int = 0
     max_satellites: int = 0
-    accuracy: str = None
-    last_summary: datetime.datetime = dataclasses.field(
-        default_factory=datetime.datetime.now
-    )
+    accuracy: str = "no fix yet"
+    # Monotonic, for the same reason as Throttle.
+    last_summary: float = dataclasses.field(default_factory=time.monotonic)
 
     def due(self, summary_interval):
-        elapsed = (datetime.datetime.now() - self.last_summary).total_seconds()
-        return elapsed >= summary_interval
+        return time.monotonic() - self.last_summary >= summary_interval
 
     def emit(self, config):
-        minutes = (datetime.datetime.now() - self.last_summary).total_seconds() // 60
+        elapsed = time.monotonic() - self.last_summary
+        minutes = int(elapsed // 60)
+        # summary_interval can be under a minute, where "0 minutes" reads as a bug.
+        span = f"{minutes} minutes" if minutes else f"{int(elapsed)} seconds"
         preamble = (
             f"Published {self.published_updates} updates to the device_tracker "
-            f"in last {minutes} minutes."
+            f"in last {span}."
         )
 
         if config.min_n_satellites == 0:
@@ -191,7 +220,7 @@ class Stats:
 
         self.published_updates = 0
         self.max_satellites = 0
-        self.last_summary = datetime.datetime.now()
+        self.last_summary = time.monotonic()
 
 
 def get_unique_identifier():
@@ -215,10 +244,20 @@ def publish_discovery(client, topics, unique_id):
     permanently unavailable device on every restart until someone manually
     clears the topic. Re-announcing on `homeassistant/status` covers the restart
     case instead, and leaves nothing behind.
+
+    Called from on_connect, so it re-fires on every reconnect. Nothing is
+    retained, so after a broker restart no copy of the config exists anywhere.
     """
     device = {
         "name": "GPSD Service",
         "identifiers": f"gpsd2mqtt_{unique_id}",
+    }
+
+    # Marks both entities unavailable on "offline" or on the last will.
+    availability = {
+        "availability_topic": topics.availability,
+        "payload_available": PAYLOAD_ONLINE,
+        "payload_not_available": PAYLOAD_OFFLINE,
     }
 
     device_tracker = {
@@ -231,6 +270,7 @@ def publish_discovery(client, topics, unique_id):
         "payload_reset": "check_zone",
         "object_id": "gps_location",
         "icon": "mdi:map-marker",
+        **availability,
         "device": {
             **device,
             "configuration_url": "https://github.com/corvy/ha-addons/tree/main/gpsd2mqtt",
@@ -246,6 +286,7 @@ def publish_discovery(client, topics, unique_id):
         "platform": "mqtt",
         "state_topic": topics.sky_state,
         "json_attributes_topic": topics.sky_attr,
+        **availability,
         "device": device,
     }
 
@@ -258,9 +299,28 @@ def publish_discovery(client, topics, unique_id):
     client.publish(topics.config, json.dumps(device_tracker))
     client.publish(topics.sky_config, json.dumps(sky_sensor))
 
+    # After the configs, so Home Assistant knows which topic to watch first.
+    client.publish(topics.availability, PAYLOAD_ONLINE)
+
     logger.info("Published MQTT discovery message to topic: %s", topics.config)
     logger.debug("Device tracker discovery payload: %s", device_tracker)
     logger.debug("Sky sensor discovery payload: %s", sky_sensor)
+
+
+class ConnectionState:
+    """Last CONNACK result, written by the paho thread and read by main()."""
+
+    def __init__(self):
+        self.last_rc = None
+
+    @property
+    def is_fatal(self):
+        return self.last_rc in FATAL_CONNECT_CODES
+
+    def describe(self):
+        if self.last_rc is None:
+            return "no response from broker yet"
+        return FATAL_CONNECT_CODES.get(self.last_rc, f"return code {self.last_rc}")
 
 
 def build_client(config, topics, unique_id):
@@ -269,11 +329,15 @@ def build_client(config, topics, unique_id):
     Reconnection is left to paho: loop_start() retries in the background using
     the backoff set by reconnect_delay_set(), and on_connect runs again on every
     successful reconnect.
+
+    Returns the client and the ConnectionState its callbacks write to.
     """
+    state = ConnectionState()
 
     def on_connect(client, userdata, flags, rc):
+        state.last_rc = rc
         if rc != 0:
-            logger.error("Failed to connect, return code: %s", rc)
+            logger.error("Failed to connect: %s", state.describe())
             return
 
         logger.info("Connected to MQTT broker")
@@ -283,6 +347,9 @@ def build_client(config, topics, unique_id):
         logger.info(
             "Subscribe to MQTT topic %s to listen for HA reboots.", HA_STATUS_TOPIC
         )
+        # On every connect, not just the first: nothing is retained, so a broker
+        # restart leaves Home Assistant with no config to rediscover us from.
+        publish_discovery(client, topics, unique_id)
 
     def on_disconnect(client, userdata, rc):
         if rc != 0:
@@ -313,7 +380,11 @@ def build_client(config, topics, unique_id):
         min_delay=RECONNECT_MIN_DELAY, max_delay=RECONNECT_MAX_DELAY
     )
 
-    return client
+    # Unretained, so nothing lingers on the broker after an uninstall. Must be
+    # set before connecting; paho sends it as part of CONNECT.
+    client.will_set(topics.availability, PAYLOAD_OFFLINE, retain=False)
+
+    return client, state
 
 
 def normalise_tpv(report):
@@ -384,7 +455,11 @@ def handle_tpv(client, topics, report, config, throttle, stats):
 
 
 def stream_gps(client, topics, config, stats):
-    """Consume one gpsd session, publishing reports until the stream ends."""
+    """Consume one gpsd session, publishing until the stream ends.
+
+    Returns the number of reports seen, so the caller can tell a gpsd that is
+    restarting from one that is simply not there.
+    """
     # SKY and TPV each get their own throttle. Sharing a single timestamp meant
     # SKY updates were only rate-limited when a TPV update happened to reset the
     # clock, so they streamed unthrottled whenever TPV was being withheld.
@@ -393,11 +468,13 @@ def stream_gps(client, topics, config, stats):
 
     # Withhold position updates until the configured satellite count is met.
     publish_position = config.min_n_satellites == 0
+    seen = 0
 
-    with GPSDClient(host=GPSD_HOST) as gps_client:
+    with GPSDClient(host=GPSD_HOST, timeout=GPSD_STREAM_TIMEOUT) as gps_client:
         for raw_report in gps_client.json_stream():
+            seen += 1
             if not _running:
-                return
+                return seen
 
             try:
                 report = json.loads(raw_report)
@@ -418,15 +495,53 @@ def stream_gps(client, topics, config, stats):
             if stats.due(config.summary_interval):
                 stats.emit(config)
 
+    return seen
 
-def wait_for_connection(client):
-    """Block until the broker accepts us, or until we are asked to shut down."""
+
+def interruptible_sleep(seconds):
+    """Sleep in slices so a shutdown request is noticed.
+
+    time.sleep() is resumed after a signal handler runs (PEP 475), so a plain
+    sleep would wait out its full duration on SIGTERM.
+    """
+    deadline = time.monotonic() + seconds
+    while _running and time.monotonic() < deadline:
+        time.sleep(0.25)
+
+
+def wait_for_connection(client, config, state):
+    """Block until the broker accepts us. Returns True if it did."""
     waited = 0
     while _running and not client.is_connected():
+        if state.is_fatal:
+            logger.error(
+                "MQTT broker rejected the connection: %s. Check the MQTT username "
+                "and password in the add-on configuration.",
+                state.describe(),
+            )
+            return False
+
+        if waited >= CONNECT_TIMEOUT:
+            logger.error(
+                "Gave up waiting for MQTT broker %s:%s after %s seconds (%s).",
+                config.mqtt_broker,
+                config.mqtt_port,
+                CONNECT_TIMEOUT,
+                state.describe(),
+            )
+            return False
+
         time.sleep(1)
         waited += 1
-        if waited % 5 == 0:
-            logger.info("Verifying MQTT Connection ....")
+        if waited % 15 == 0:
+            logger.info(
+                "Still waiting for MQTT broker %s:%s (%s).",
+                config.mqtt_broker,
+                config.mqtt_port,
+                state.describe(),
+            )
+
+    return client.is_connected()
 
 
 def handle_shutdown(signum, frame):
@@ -453,36 +568,82 @@ def main():
     logger.debug("MQTT Config: %s", topics.config)
     logger.debug("MQTT Attribute: %s", topics.attr)
 
-    client = build_client(config, topics, unique_id)
+    client, state = build_client(config, topics, unique_id)
 
     # connect_async tolerates a broker that is not up yet: loop_start keeps
     # retrying in the background instead of raising here.
     logger.info("Connecting to MQTT broker")
     client.connect_async(config.mqtt_broker, config.mqtt_port)
     client.loop_start()
-    wait_for_connection(client)
 
-    if _running:
-        publish_discovery(client, topics, unique_id)
+    # paho drops QoS 0 publishes while disconnected, so wait before streaming.
+    # Discovery is sent from on_connect.
+    if not wait_for_connection(client, config, state):
+        client.loop_stop()
+        return 0 if not _running else 1
 
+    exit_code = 0
     stats = Stats()
+    barren_sessions = 0
+
     while _running:
         logger.info("Starting location detection and sending GPS updates.")
         try:
-            stream_gps(client, topics, config, stats)
+            seen = stream_gps(client, topics, config, stats)
+        except TimeoutError:
+            # gpsd went quiet; the stream can only be reopened, not resumed.
+            seen = 0
+            logger.info(
+                "No data from gpsd in %s seconds, reopening the stream.",
+                GPSD_STREAM_TIMEOUT,
+            )
         except Exception as err:  # gpsd restarting, socket dropped, bad frame
+            seen = 0
             logger.error("Lost connection to gpsd: %s", err)
+        else:
+            logger.info("gpsd stream ended after %s reports.", seen)
+
+        # A session yielding nothing means gpsd is absent, not just restarting.
+        # Enough in a row and we exit non-zero so the Supervisor restarts the
+        # add-on, and gpsd with it.
+        barren_sessions = barren_sessions + 1 if seen == 0 else 0
+        if barren_sessions >= MAX_BARREN_SESSIONS:
+            logger.error(
+                "No data from gpsd across %s attempts. Giving up so the add-on "
+                "is restarted -- check the GPS device and the log above for gpsd "
+                "startup errors.",
+                barren_sessions,
+            )
+            exit_code = 1
+            break
 
         if _running:
             logger.info(
                 "gpsd stream ended, reconnecting in %s seconds.", GPSD_RETRY_DELAY
             )
-            time.sleep(GPSD_RETRY_DELAY)
+            interruptible_sleep(GPSD_RETRY_DELAY)
 
     logger.info("Disconnecting from MQTT broker.")
-    client.loop_stop()
+    publish_offline(client, topics)
+    # disconnect() before loop_stop(): the network loop writes the packet.
     client.disconnect()
+    client.loop_stop()
+    return exit_code
+
+
+def publish_offline(client, topics):
+    """Announce departure and wait for it to reach the socket.
+
+    The broker discards the last will on a clean disconnect, so a clean stop has
+    to say so itself. publish() only queues, and the network thread is stopping.
+    """
+    try:
+        info = client.publish(topics.availability, PAYLOAD_OFFLINE)
+        info.wait_for_publish(timeout=SHUTDOWN_PUBLISH_TIMEOUT)
+    except (ValueError, RuntimeError) as err:
+        # Not worth failing a shutdown over; the broker sends the will instead.
+        logger.debug("Could not publish offline availability: %s", err)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/gpsd2mqtt_beta/run.sh
+++ b/gpsd2mqtt_beta/run.sh
@@ -73,6 +73,9 @@ else
     echo "Starting MQTT Publisher with username ${MQTT_USER} ... "
 fi
 
+# Python is unpinned and follows the Alpine base; log which one is running.
+echo "Using $(python3 --version 2>&1)"
+
 # Credentials go through the environment rather than the command line: argv
 # would expose the password in `ps`, and an unquoted password containing spaces
 # would be split into separate arguments.

--- a/scripts/check_addons.py
+++ b/scripts/check_addons.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 """Check invariants across the add-on config.yaml files.
 
-`config.yaml` is deliberately excluded from `gpsd2mqtt_beta/rsync.sh`, because the
-slug, name, version and image must differ between the two channels. The cost is
-that schema changes have to be mirrored by hand, and nothing used to notice when
-that was forgotten -- `mqtt_state` was removed from beta in 2026.8.0 and the prod
-changelog said so, but it sat in the prod schema for another release.
+`config.yaml` is excluded from `gpsd2mqtt_beta/rsync.sh` because slug, name,
+version and image must differ between channels, so schema changes have to be
+mirrored by hand. This catches the ones that are not.
 
 Run from the repository root, or with the repository root as the only argument.
 """
@@ -16,8 +14,7 @@ import sys
 
 import yaml
 
-# The two channels of the same add-on. Everything a user configures must be
-# identical between them; only packaging differs.
+# Two channels of one add-on; only packaging may differ between them.
 MIRRORED_CHANNELS = ("gpsd2mqtt", "gpsd2mqtt_beta")
 
 # Keys that must match across the channels above.
@@ -72,9 +69,7 @@ def check_versions(addons, errors):
             errors.append(f"{slug}/config.yaml has no version")
             continue
 
-        # Two add-ons at the same version would collide on the GitHub release tag
-        # created by .github/workflows/release.yaml, and the second would be
-        # silently skipped.
+        # Release tags come from version:, so a collision silently skips one.
         if version in seen:
             errors.append(
                 f"{slug} and {seen[version]} both declare version {version}; "
@@ -82,8 +77,7 @@ def check_versions(addons, errors):
             )
         seen[version] = slug
 
-        # This is what keeps the uniqueness above true by construction rather
-        # than by luck: beta always carries the suffix, prod never does.
+        # Keeps the uniqueness above true by construction.
         is_beta_channel = slug.endswith("_beta")
         has_beta_suffix = bool(BETA_SUFFIX.search(version))
         if is_beta_channel and not has_beta_suffix:
@@ -99,9 +93,8 @@ def check_images(addons, errors):
         image = config.get("image")
         if not image:
             continue
-        # Prod pointed at the beta image repository for eight months in 2025
-        # because both folders build identical code, so the mislabelled image
-        # worked and nobody noticed.
+        # Both folders build identical code, so a mislabelled image still works
+        # and goes unnoticed.
         if image in seen:
             errors.append(
                 f"{slug} and {seen[image]} both publish to {image}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,8 @@
 """Shared fixtures.
 
-The add-on script is imported from `gpsd2mqtt_beta/`, which is the source of truth --
-`gpsd2mqtt/` is a copy produced by `gpsd2mqtt_beta/rsync.sh` and must never be edited
-directly. Tests live at the repository root rather than inside either add-on so that
-rsync does not duplicate them into the release folder.
+Imports the add-on script from `gpsd2mqtt_beta/`, the source of truth;
+`gpsd2mqtt/` is an rsync copy. Tests live at the repository root so rsync does
+not duplicate them into the release folder.
 """
 
 import pathlib
@@ -14,8 +13,7 @@ import pytest
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 ADDON_SOURCE = REPO_ROOT / "gpsd2mqtt_beta"
 
-# Prepended, not appended: the prod add-on directory is also named `gpsd2mqtt`, and
-# being first means the module file always wins over the directory.
+# Prepended so the module file wins over the prod directory of the same name.
 sys.path.insert(0, str(ADDON_SOURCE))
 
 import gpsd2mqtt  # noqa: E402
@@ -28,12 +26,16 @@ def module():
 
 
 class FakePublish:
-    """One recorded call to `client.publish()`."""
+    """One recorded call to `client.publish()`, doubling as its MQTTMessageInfo."""
 
     def __init__(self, topic, payload, retain):
         self.topic = topic
         self.payload = payload
         self.retain = retain
+        self.waited_for = None
+
+    def wait_for_publish(self, timeout=None):
+        self.waited_for = timeout
 
     def json(self):
         import json
@@ -53,7 +55,9 @@ class FakeClient:
         self.will = None
 
     def publish(self, topic, payload=None, qos=0, retain=False):
-        self.published.append(FakePublish(topic, payload, retain))
+        call = FakePublish(topic, payload, retain)
+        self.published.append(call)
+        return call
 
     def subscribe(self, topic):
         self.subscribed.append(topic)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,170 @@
+"""Broker connection handling: the will, discovery on reconnect, and giving up.
+
+`build_client` is exercised against a real paho client -- constructing one does
+no I/O -- so the will is checked as paho actually stored it rather than as we
+hoped to have set it.
+"""
+
+import pytest
+
+# --- ConnectionState -------------------------------------------------------
+
+
+def test_auth_failures_are_recognised_as_fatal(module):
+    state = module.ConnectionState()
+
+    for rc in (4, 5):
+        state.last_rc = rc
+        assert state.is_fatal, f"CONNACK {rc} can never succeed on retry"
+
+
+def test_transient_failures_are_not_fatal(module):
+    state = module.ConnectionState()
+
+    # 3 is "server unavailable" -- worth waiting out, the broker may be booting.
+    for rc in (None, 0, 1, 2, 3):
+        state.last_rc = rc
+        assert not state.is_fatal
+
+
+def test_state_describes_the_failure_in_words(module):
+    state = module.ConnectionState()
+
+    assert "no response" in state.describe()
+    state.last_rc = 5
+    assert state.describe() == "not authorised"
+    state.last_rc = 3
+    assert "3" in state.describe()
+
+
+# --- build_client ----------------------------------------------------------
+
+
+@pytest.fixture
+def built(module, config_factory, topics):
+    client, state = module.build_client(config_factory(), topics, "abc12345")
+    yield client, state
+    client.loop_stop()
+
+
+def test_last_will_is_registered_before_connecting(built, topics, module):
+    client, _ = built
+
+    assert client._will is True
+    assert client._will_topic == topics.availability.encode()
+    assert client._will_payload == module.PAYLOAD_OFFLINE.encode()
+
+
+def test_last_will_is_not_retained(built):
+    """A retained will would outlive the add-on on the broker after uninstall."""
+    client, _ = built
+
+    assert client._will_retain is False
+
+
+def test_connecting_publishes_discovery(built, client, topics):
+    """Not just on the first connect -- this is what makes a broker restart recover."""
+    paho_client, _ = built
+
+    paho_client.on_connect(client, None, None, 0)
+
+    assert client.for_topic(topics.config)
+    assert client.for_topic(topics.sky_config)
+    assert client.for_topic(topics.availability)
+
+
+def test_connecting_subscribes_to_home_assistant_status(built, client, module):
+    paho_client, _ = built
+
+    paho_client.on_connect(client, None, None, 0)
+
+    assert module.HA_STATUS_TOPIC in client.subscribed
+
+
+def test_a_rejected_connect_publishes_nothing(built, client):
+    paho_client, state = built
+
+    paho_client.on_connect(client, None, None, 5)
+
+    assert client.published == []
+    assert state.last_rc == 5
+
+
+def test_home_assistant_restart_republishes_discovery(built, client, topics, module):
+    paho_client, _ = built
+
+    class Message:
+        topic = module.HA_STATUS_TOPIC
+        payload = b"online"
+
+    paho_client.on_message(client, None, Message())
+
+    assert client.for_topic(topics.config)
+
+
+# --- wait_for_connection ---------------------------------------------------
+
+
+class StubClient:
+    def __init__(self, connected):
+        self._connected = connected
+
+    def is_connected(self):
+        return self._connected
+
+
+def test_wait_returns_immediately_when_connected(module, config_factory):
+    state = module.ConnectionState()
+
+    assert module.wait_for_connection(StubClient(True), config_factory(), state) is True
+
+
+def test_wait_gives_up_on_bad_credentials(module, config_factory, caplog, monkeypatch):
+    """Retrying a rejected password forever only buries the one useful log line."""
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    state = module.ConnectionState()
+    state.last_rc = 5
+
+    result = module.wait_for_connection(StubClient(False), config_factory(), state)
+
+    assert result is False
+    assert "not authorised" in caplog.text
+    assert "username" in caplog.text.lower()
+
+
+def test_wait_gives_up_after_the_timeout(module, config_factory, caplog, monkeypatch):
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(module, "CONNECT_TIMEOUT", 3)
+    state = module.ConnectionState()
+
+    result = module.wait_for_connection(StubClient(False), config_factory(), state)
+
+    assert result is False
+    assert "Gave up waiting" in caplog.text
+
+
+def test_wait_reports_the_broker_it_is_waiting_for(
+    module, config_factory, caplog, monkeypatch
+):
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(module, "CONNECT_TIMEOUT", 20)
+    state = module.ConnectionState()
+
+    module.wait_for_connection(
+        StubClient(False), config_factory(mqtt_broker="broker.example"), state
+    )
+
+    assert "broker.example" in caplog.text
+
+
+# --- shutdown --------------------------------------------------------------
+
+
+def test_interruptible_sleep_stops_when_shutdown_is_requested(module, monkeypatch):
+    """A plain time.sleep is resumed after a signal, so a stop would wait it out."""
+    monkeypatch.setattr(module, "_running", False)
+
+    started = module.time.monotonic()
+    module.interruptible_sleep(30)
+
+    assert module.time.monotonic() - started < 1

--- a/tests/test_publishing.py
+++ b/tests/test_publishing.py
@@ -68,9 +68,70 @@ def test_both_entities_share_one_device(module, client, topics):
 def test_discovery_payloads_are_valid_json(module, client, topics):
     module.publish_discovery(client, topics, "abc12345")
 
-    for call in client.published:
-        if call.payload:
-            json.loads(call.payload)
+    for topic in (topics.config, topics.sky_config):
+        json.loads(client.for_topic(topic)[0].payload)
+
+
+# --- availability ----------------------------------------------------------
+
+
+def test_discovery_announces_us_as_online(module, client, topics):
+    module.publish_discovery(client, topics, "abc12345")
+
+    calls = client.for_topic(topics.availability)
+
+    assert len(calls) == 1
+    assert calls[0].payload == module.PAYLOAD_ONLINE
+
+
+def test_online_is_announced_after_the_configs(module, client, topics):
+    """Home Assistant needs to know which topic to watch before being told we are up."""
+    module.publish_discovery(client, topics, "abc12345")
+
+    order = client.topics()
+
+    assert order.index(topics.availability) > order.index(topics.config)
+    assert order.index(topics.availability) > order.index(topics.sky_config)
+
+
+def test_availability_is_not_retained(module, client, topics):
+    """Same reasoning as discovery: nothing may outlive the add-on on the broker."""
+    module.publish_discovery(client, topics, "abc12345")
+
+    assert client.for_topic(topics.availability)[0].retain is False
+
+
+def test_both_entities_declare_the_availability_topic(module, client, topics):
+    module.publish_discovery(client, topics, "abc12345")
+
+    tracker = client.for_topic(topics.config)[0].json()
+    sky = client.for_topic(topics.sky_config)[0].json()
+
+    for payload in (tracker, sky):
+        assert payload["availability_topic"] == topics.availability
+        assert payload["payload_available"] == module.PAYLOAD_ONLINE
+        assert payload["payload_not_available"] == module.PAYLOAD_OFFLINE
+
+
+def test_shutdown_announces_offline(module, client, topics):
+    module.publish_offline(client, topics)
+
+    calls = client.for_topic(topics.availability)
+
+    assert len(calls) == 1
+    assert calls[0].payload == module.PAYLOAD_OFFLINE
+    assert calls[0].retain is False
+
+
+def test_shutdown_survives_a_broker_that_has_already_gone(module, client, topics):
+    """A failed goodbye must not turn a clean stop into a crash."""
+
+    def exploding_publish(*args, **kwargs):
+        raise RuntimeError("Message publish failed: The client is not currently connected.")
+
+    client.publish = exploding_publish
+
+    module.publish_offline(client, topics)  # must not raise
 
 
 # --- SKY -------------------------------------------------------------------

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -72,6 +72,7 @@ def test_topic_names_are_stable(module):
     assert topics.sky_config == "homeassistant/sensor/gpsd2mqtt/abc12345_sky/config"
     assert topics.sky_state == "gpsd2mqtt/abc12345_sky/state"
     assert topics.sky_attr == "gpsd2mqtt/abc12345_sky/attribute"
+    assert topics.availability == "gpsd2mqtt/abc12345/availability"
 
 
 def test_unique_identifier_is_stable_and_short(module):
@@ -179,3 +180,43 @@ def test_summary_is_not_due_immediately(module):
     stats = module.Stats()
 
     assert not stats.due(3600)
+
+
+def test_summary_reports_seconds_when_the_interval_is_short(
+    module, config_factory, caplog
+):
+    """"in last 0 minutes" reads as a bug; sub-minute intervals are configurable."""
+    stats = module.Stats(published_updates=1, max_satellites=5, accuracy="3D fix")
+
+    with caplog.at_level(logging.INFO, logger="gpsd2mqtt"):
+        stats.emit(config_factory())
+
+    assert "0 minutes" not in caplog.text
+    assert "seconds" in caplog.text
+
+
+def test_summary_before_any_fix_does_not_say_none(module, config_factory, caplog):
+    """The first summary can land before any TPV has arrived."""
+    stats = module.Stats()
+
+    with caplog.at_level(logging.INFO, logger="gpsd2mqtt"):
+        stats.emit(config_factory())
+
+    assert "Achieved None" not in caplog.text
+
+
+def test_clocks_are_monotonic(module):
+    """Wall clock would stall every publish if chrony stepped the clock backwards.
+
+    gpsd is itself a common time source on these installs, so this is not
+    hypothetical.
+    """
+    throttle = module.Throttle(10)
+    stats = module.Stats()
+
+    # A wall-clock implementation would hold a datetime here, not a float from
+    # time.monotonic(). Monotonic values are also unrelated to the epoch.
+    assert isinstance(throttle._last, float)
+    assert isinstance(stats.last_summary, float)
+    assert throttle._last < time.time() - 3600 * 24
+    assert stats.last_summary < time.time() - 3600 * 24


### PR DESCRIPTION
Monotonic clocks in Throttle and Stats. Wall clock stalled publishing for as long as the system clock was stepped backwards, which happens on installs where GPS also feeds chrony.

Publish discovery from on_connect so it is re-sent on every broker reconnect. Nothing is retained, so after a broker restart the config previously existed nowhere and the entities never came back without an HA restart.

Add an unretained availability topic and last will. Entities show unavailable when the add-on stops, cleanly or otherwise, and nothing is left on the broker after an uninstall.

Exit non-zero on a CONNACK the configuration cannot fix, and add a connect timeout, instead of looping forever on "Verifying MQTT Connection ....".

Supervise gpsd: a watchdog on port 2947 plus a barren-session counter that gives up after about a minute without data. Nothing restarted gpsd before, so a dead receiver left the add-on running and apparently healthy.

Interruptible retry sleep, so SIGTERM no longer waits out the full 5s.

Loosen gpsd to >=3.27.1 . The edge override stays
until Alpine stable moves past 3.26.1, which still carries CVE-2025-67268 and CVE-2025-67269.

Drop the hardcoded pythoprofile, and log the
python version at startup.